### PR TITLE
Add first REST endpoint for getting all log data

### DIFF
--- a/glados.iml
+++ b/glados.iml
@@ -20,7 +20,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_10">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">

--- a/glados.iml
+++ b/glados.iml
@@ -3,9 +3,7 @@
   <component name="FacetManager">
     <facet type="ejb" name="EJB">
       <configuration>
-        <ejbRoots>
-          <root url="file://$MODULE_DIR$/src" />
-        </ejbRoots>
+        <ejbRoots />
       </configuration>
     </facet>
     <facet type="web" name="Web">
@@ -22,7 +20,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_10">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">
@@ -38,6 +36,12 @@
     <orderEntry type="library" scope="PROVIDED" name="GlassFish 5.0.0 - EJB" level="application_server_libraries" />
     <orderEntry type="library" scope="PROVIDED" name="GlassFish 5.0.0 - JSF" level="application_server_libraries" />
     <orderEntry type="library" scope="PROVIDED" name="GlassFish 5.0.0 - CDI: Contexts and Dependency Injection" level="application_server_libraries" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax:javaee-api:8.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.sun.mail:javax.mail:1.6.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.activation:activation:1.1" level="project" />
+    <orderEntry type="library" name="Maven: javax.json:javax.json-api:1.1" level="project" />
+    <orderEntry type="library" name="Maven: org.glassfish:javax.json:1.1" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.5" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-api:5.3.1" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.0.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.opentest4j:opentest4j:1.1.1" level="project" />
@@ -52,5 +56,6 @@
     <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy:1.9.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy-agent:1.9.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:2.6" level="project" />
+    <orderEntry type="library" name="Maven: org.jetbrains:annotations:16.0.3" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
@@ -99,8 +100,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>10</source>
-                    <target>10</target>
+                    <source>8</source>
+                    <target>8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,40 @@
     <version>0.1</version>
 
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>
+        <dependency>
+            <!-- Java EE REST API-->
+            <groupId>javax</groupId>
+            <artifactId>javaee-api</artifactId>
+            <version>8.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <version>1.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1</version>
+        </dependency>
+
+
+        <!-- GSON -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.5</version>
+        </dependency>
+
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -40,6 +69,12 @@
             <version>2.23.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>RELEASE</version>
+            <scope>compile</scope>
+        </dependency>
 
     </dependencies>
 
@@ -60,6 +95,14 @@
                 </execution>
             </executions>
         </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>10</source>
+                    <target>10</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/ExceptionMapper.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/ExceptionMapper.java
@@ -1,0 +1,11 @@
+package uk.ac.aber.dcs.aberfitness.glados.api;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Defines a mapping between Java exceptions to response codes
+ * @param <E> The exception to map to a response code
+ */
+public interface ExceptionMapper<E extends Throwable> {
+    Response toResponse(E exception);
+}

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/GsonTimeDeserialiser.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/GsonTimeDeserialiser.java
@@ -1,0 +1,33 @@
+package uk.ac.aber.dcs.aberfitness.glados.api;
+
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+public class GsonTimeDeserialiser {
+    public static final JsonDeserializer<Instant> INSTANT_DESERIALISER = new JsonDeserializer<Instant>() {
+
+        // Adapted from https://stackoverflow.com/a/36418842
+        // Author: zyexal , Posted : 2016/04/05
+
+        @Override
+        public Instant deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext) throws JsonParseException {
+            JsonPrimitive jsonPrimitive = jsonElement.getAsJsonPrimitive();
+            try {
+
+                // if provided as String - '2011-12-03T10:15:30+01:00[Europe/Paris]'
+                if(jsonPrimitive.isString()){
+                    return Instant.parse(jsonPrimitive.getAsString());
+                }
+
+            } catch(RuntimeException e){
+                throw new JsonParseException("Unable to parse Instant Timestamp", e);
+            }
+            throw new JsonParseException("Unable to parse Instant Timestamp");
+        }
+    };
+
+
+}

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/IoExceptionWrapper.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/IoExceptionWrapper.java
@@ -1,0 +1,18 @@
+package uk.ac.aber.dcs.aberfitness.glados.api;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+
+/**
+ * Converts IOExceptions into InternalServer Error responses within the
+ * Javax Ws layer
+ */
+@Provider
+public class IoExceptionWrapper implements ExceptionMapper<IOException> {
+    @Override
+    public Response toResponse(IOException exception) {
+        return Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+    }
+}

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/JAXRSConfiguration.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/JAXRSConfiguration.java
@@ -1,0 +1,8 @@
+package uk.ac.aber.dcs.aberfitness.glados.api;
+
+import javax.ws.rs.ApplicationPath;
+
+// Defines the base endpoint path
+@ApplicationPath("api")
+public class JAXRSConfiguration {
+}

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/LogApi.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/LogApi.java
@@ -1,0 +1,38 @@
+package uk.ac.aber.dcs.aberfitness.glados.api;
+
+import uk.ac.aber.dcs.aberfitness.glados.db.DatabaseConnection;
+import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
+
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonArrayBuilder;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.util.List;
+
+@Stateless
+@Path("log")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class LogApi {
+    @Inject
+    DatabaseConnection dbConnection;
+
+    @GET
+    public JsonArray getAllEntries() throws IOException {
+        // TODO add limits / ranges
+        final JsonArrayBuilder jsonArray = Json.createArrayBuilder();
+        List<LogData> foundEntries = dbConnection.getAllLogEntries();
+        foundEntries.forEach(e->jsonArray.add(e.toJson()));
+        return jsonArray.build();
+    }
+
+
+
+}

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/DatabaseConnection.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/DatabaseConnection.java
@@ -1,0 +1,47 @@
+package uk.ac.aber.dcs.aberfitness.glados.db;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public class DatabaseConnection implements IDatabaseConnection{
+    // TODO
+    public DatabaseConnection(){
+    }
+
+    @Override
+    public void connectToDatabase() throws ConnectException {
+
+    }
+
+    @Override
+    public void disconnectFromDb() throws ConnectException {
+
+    }
+
+    @Override
+    public void addLogData(LogData newLogEntry) throws IOException {
+
+    }
+
+    @Override
+    public LogData getLogEntry(String logId) throws IOException, NoSuchElementException {
+        return null;
+    }
+
+    @Override
+    public List<LogData> findLogEntry(LogData searchCriteria) throws IOException {
+        return null;
+    }
+
+    @Override
+    public List<LogData> getAllLogEntries() throws IOException {
+        return null;
+    }
+
+    @Override
+    public void removeLogData(String logId) throws IOException {
+
+    }
+}

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/IDatabaseConnection.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/IDatabaseConnection.java
@@ -54,6 +54,15 @@ public interface IDatabaseConnection {
     List<LogData> findLogEntry(LogData searchCriteria) throws IOException;
 
     /**
+     * Returns all log entries within the DB as a list.
+     * If the request fails an IOException is thrown
+     * @return A list containing all log entries from the database
+     * @throws IOException If the request could not be completed
+     */
+    // TODO add limits
+    List<LogData> getAllLogEntries() throws IOException;
+
+    /**
      * Attempts to remove the given logId. The entry is allowed to not exist too.
      * If the request fails an IOException is thrown
      * @param logId The unique ID of the log entry to remove

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
@@ -5,9 +5,12 @@ import com.google.gson.GsonBuilder;
 import uk.ac.aber.dcs.aberfitness.glados.api.GsonTimeDeserialiser;
 
 import javax.json.Json;
+import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -93,6 +96,16 @@ public class LogData {
 
         Gson gson = gsonBuilder.create();
         return gson.fromJson(jsonObject.toString(), LogData.class);
+    }
+
+    public static List<LogData> fromJson(JsonArray jsonArray){
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        // Register a custom adaptor to convert to instant from strings
+        gsonBuilder.registerTypeAdapter(Instant.class, GsonTimeDeserialiser.INSTANT_DESERIALISER);
+
+        Gson gson = gsonBuilder.create();
+        LogData[] converted = gson.fromJson(jsonArray.toString(), LogData[].class);
+        return Arrays.asList(converted);
     }
 
     @Override

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
@@ -1,6 +1,13 @@
 package uk.ac.aber.dcs.aberfitness.glados.db;
 
-import java.util.Date;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import uk.ac.aber.dcs.aberfitness.glados.api.GsonTimeDeserialiser;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -15,7 +22,7 @@ public class LogData {
      * @param content The message content of this log entry
      * @param userId The user associated with this log entry
      */
-    public LogData(final Date timestamp, final LoggingLevel logLevel,
+    public LogData(final Instant timestamp, final LoggingLevel logLevel,
                    final String content, final String userId) {
         this.logId = UUID.randomUUID().toString();
         this.timestamp = timestamp;
@@ -28,7 +35,7 @@ public class LogData {
      * Returns the timestamp of the specified log message
      * @return Date object with the log's timestamp
      */
-    public Date getTimestamp() {
+    public Instant getTimestamp() {
         return timestamp;
     }
 
@@ -65,8 +72,48 @@ public class LogData {
         return logId;
     }
 
+    /**
+     * Serialises the current object into a new JSON object
+     * @return A json object for the current record
+     */
+    public JsonObject toJson(){
+        JsonObjectBuilder newJson = Json.createObjectBuilder();
+        newJson.add("logId", this.logId)
+               .add("timestamp", this.timestamp.toString())
+               .add("userId", this.userId)
+               .add("logLevel", this.logLevel.toString())
+               .add("content", this.content);
+        return newJson.build();
+    }
+
+    public static LogData fromJson(JsonObject jsonObject){
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        // Register a custom adaptor to convert to instant from strings
+        gsonBuilder.registerTypeAdapter(Instant.class, GsonTimeDeserialiser.INSTANT_DESERIALISER);
+
+        Gson gson = gsonBuilder.create();
+        return gson.fromJson(jsonObject.toString(), LogData.class);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null){
+            return false;
+        }
+
+        if (!LogData.class.isAssignableFrom(obj.getClass())){
+            return false;
+        }
+
+        final LogData other = (LogData) obj;
+        return this.logId.equals(other.logId) && this.timestamp.equals(other.timestamp)
+                && this.logLevel == other.logLevel && this.content.equals(other.content) &&
+                this.userId.equals(other.userId);
+
+    }
+
     private String logId;
-    private Date timestamp;
+    private Instant timestamp;
     private LoggingLevel logLevel;
     private String content;
     private String userId;

--- a/src/test/java/LogApiTest.java
+++ b/src/test/java/LogApiTest.java
@@ -1,0 +1,47 @@
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.ac.aber.dcs.aberfitness.glados.api.LogApi;
+import uk.ac.aber.dcs.aberfitness.glados.db.DatabaseConnection;
+import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
+import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevel;
+
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+public class LogApiTest {
+    @Mock
+    private DatabaseConnection dbMock;
+
+    // Ensure we replace the injected concrete type with
+    @InjectMocks
+    private LogApi apiInstance;
+
+    @Before
+    public void setUp() {
+        apiInstance = new LogApi();
+        MockitoAnnotations.initMocks(this);
+    }
+
+
+
+    @Test
+    public void findAllCallReturnsAll() throws IOException {
+        LogData entryOne = new LogData(Instant.now(), LoggingLevel.DEBUG, "testContent", "abc123");
+        LogData entryTwo = new LogData(Instant.now(), LoggingLevel.WARNING, "testContent2", "xyz987");
+
+        List<LogData> mockedData = List.of(entryOne, entryTwo);
+
+        JsonArray returnedData = apiInstance.getAllEntries();
+
+
+
+    }
+
+}

--- a/src/test/java/LogApiTest.java
+++ b/src/test/java/LogApiTest.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
 
+import static org.mockito.Mockito.when;
+
 public class LogApiTest {
     @Mock
     private DatabaseConnection dbMock;
@@ -36,6 +38,8 @@ public class LogApiTest {
         LogData entryTwo = new LogData(Instant.now(), LoggingLevel.WARNING, "testContent2", "xyz987");
 
         List<LogData> mockedData = List.of(entryOne, entryTwo);
+
+        when(dbMock.getAllLogEntries()).thenReturn(mockedData);
 
         JsonArray returnedData = apiInstance.getAllEntries();
 

--- a/src/test/java/LogApiTest.java
+++ b/src/test/java/LogApiTest.java
@@ -1,3 +1,4 @@
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -10,9 +11,9 @@ import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevel;
 
 import javax.json.JsonArray;
 import javax.json.JsonObject;
+import javax.json.JsonValue;
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 
 public class LogApiTest {
@@ -29,8 +30,6 @@ public class LogApiTest {
         MockitoAnnotations.initMocks(this);
     }
 
-
-
     @Test
     public void findAllCallReturnsAll() throws IOException {
         LogData entryOne = new LogData(Instant.now(), LoggingLevel.DEBUG, "testContent", "abc123");
@@ -40,8 +39,7 @@ public class LogApiTest {
 
         JsonArray returnedData = apiInstance.getAllEntries();
 
-
-
+        Assert.assertEquals(mockedData, LogData.fromJson(returnedData));
     }
 
 }

--- a/src/test/java/LogApiTest.java
+++ b/src/test/java/LogApiTest.java
@@ -14,6 +14,7 @@ import javax.json.JsonObject;
 import javax.json.JsonValue;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.mockito.Mockito.when;
@@ -37,7 +38,7 @@ public class LogApiTest {
         LogData entryOne = new LogData(Instant.now(), LoggingLevel.DEBUG, "testContent", "abc123");
         LogData entryTwo = new LogData(Instant.now(), LoggingLevel.WARNING, "testContent2", "xyz987");
 
-        List<LogData> mockedData = List.of(entryOne, entryTwo);
+        List<LogData> mockedData = Arrays.asList(entryOne, entryTwo);
 
         when(dbMock.getAllLogEntries()).thenReturn(mockedData);
 

--- a/src/test/java/LogDataTest.java
+++ b/src/test/java/LogDataTest.java
@@ -3,12 +3,15 @@ import org.junit.Test;
 import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
 import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevel;
 
-import java.util.Date;
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import java.time.Instant;
 
 public class LogDataTest {
     @Test
-    public void LogDataGetters(){
-        Date now = new Date();
+    public void LogDataGetters() {
+        Instant now = Instant.now();
         String sampleMsg = "Hello world";
         LoggingLevel logLevel = LoggingLevel.DEBUG;
         String userId = "test123";
@@ -22,8 +25,8 @@ public class LogDataTest {
     }
 
     @Test
-    public void LogDataGeneratesUniqueLogId(){
-        Date now = new Date();
+    public void LogDataGeneratesUniqueLogId() {
+        Instant now = Instant.now();
 
         // Regardless of other fields the log id should always be unique
         final LogData testInstanceOne = new LogData(now, LoggingLevel.DEBUG, "test", "id1");
@@ -31,5 +34,65 @@ public class LogDataTest {
 
         Assert.assertNotEquals(testInstanceOne.getLogId(), testInstanceTwo.getLogId());
     }
+
+    @Test
+    public void SerialisesToJsonCorrectly() {
+        Instant now = Instant.now();
+        String sampleMsg = "Hello world";
+        LoggingLevel logLevel = LoggingLevel.DEBUG;
+        String userId = "test123";
+
+        final LogData testInstance = new LogData(now, logLevel, sampleMsg, userId);
+        JsonObject returnedJson = testInstance.toJson();
+
+        Assert.assertNotEquals(returnedJson.getString("logId"), "");
+        Assert.assertEquals(returnedJson.getString("timestamp"), now.toString());
+        Assert.assertEquals(returnedJson.getString("userId"), userId);
+        Assert.assertEquals(returnedJson.getString("logLevel"), logLevel.toString());
+        Assert.assertEquals(returnedJson.getString("content"), sampleMsg);
+    }
+
+    @Test
+    public void SerialisesFromJsonCorrectly() {
+        Instant now = Instant.now();
+        String sampleMsg = "Hello world";
+        LoggingLevel logLevel = LoggingLevel.DEBUG;
+        String userId = "test123";
+        String fakeId = "12345";
+
+        JsonObjectBuilder newJsonObject = Json.createObjectBuilder();
+
+
+        newJsonObject.add("logId", fakeId)
+                     .add("timestamp", now.toString())
+                     .add("userId", userId)
+                     .add("logLevel", logLevel.toString())
+                     .add("content", sampleMsg);
+        JsonObject testJson = newJsonObject.build();
+
+        LogData returnedClass = LogData.fromJson(testJson);
+        Assert.assertEquals(returnedClass.getLogId(), fakeId);
+        Assert.assertEquals(returnedClass.getUserId(), userId);
+        Assert.assertEquals(returnedClass.getLogLevel(), logLevel);
+        Assert.assertEquals(returnedClass.getContent(), sampleMsg);
+        Assert.assertEquals(returnedClass.getTimestamp(), now);
+    }
+
+    @Test
+    public void SerialisesSelfCorrectly() {
+        Instant now = Instant.now();
+        String sampleMsg = "Hello world";
+        LoggingLevel logLevel = LoggingLevel.DEBUG;
+        String userId = "test123";
+
+        final LogData testInstance = new LogData(now, logLevel, sampleMsg, userId);
+
+        JsonObject returnedJson = testInstance.toJson();
+        LogData returnedObject = LogData.fromJson(returnedJson);
+
+        Assert.assertEquals(returnedObject, testInstance);
+
+    }
+
 
 }

--- a/src/test/java/LogDataTest.java
+++ b/src/test/java/LogDataTest.java
@@ -3,10 +3,9 @@ import org.junit.Test;
 import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
 import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevel;
 
-import javax.json.Json;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
+import javax.json.*;
 import java.time.Instant;
+import java.util.List;
 
 public class LogDataTest {
     @Test
@@ -52,6 +51,20 @@ public class LogDataTest {
         Assert.assertEquals(returnedJson.getString("content"), sampleMsg);
     }
 
+    private JsonObject createFakeJson(Instant time, String msg, String userId,
+                                      String logId, LoggingLevel logLevel){
+
+        JsonObjectBuilder newJsonObject = Json.createObjectBuilder();
+
+
+        newJsonObject.add("logId", logId)
+                .add("timestamp", time.toString())
+                .add("userId", userId)
+                .add("logLevel", logLevel.toString())
+                .add("content", msg);
+        return newJsonObject.build();
+    }
+
     @Test
     public void SerialisesFromJsonCorrectly() {
         Instant now = Instant.now();
@@ -60,15 +73,7 @@ public class LogDataTest {
         String userId = "test123";
         String fakeId = "12345";
 
-        JsonObjectBuilder newJsonObject = Json.createObjectBuilder();
-
-
-        newJsonObject.add("logId", fakeId)
-                     .add("timestamp", now.toString())
-                     .add("userId", userId)
-                     .add("logLevel", logLevel.toString())
-                     .add("content", sampleMsg);
-        JsonObject testJson = newJsonObject.build();
+        JsonObject testJson = createFakeJson(now, sampleMsg, userId, fakeId, logLevel);
 
         LogData returnedClass = LogData.fromJson(testJson);
         Assert.assertEquals(returnedClass.getLogId(), fakeId);
@@ -76,6 +81,30 @@ public class LogDataTest {
         Assert.assertEquals(returnedClass.getLogLevel(), logLevel);
         Assert.assertEquals(returnedClass.getContent(), sampleMsg);
         Assert.assertEquals(returnedClass.getTimestamp(), now);
+    }
+
+    @Test
+    public void SerialisesFromListCorrectly(){
+        Instant now = Instant.now();
+        String sampleMsg = "Hello world";
+        LoggingLevel logLevel = LoggingLevel.DEBUG;
+        String userId = "test123";
+
+        JsonObject testJson = createFakeJson(now, sampleMsg, userId, "101", logLevel);
+        JsonObject testJson2 = createFakeJson(now, sampleMsg, userId, "102", logLevel);
+        JsonObject testJson3 = createFakeJson(now, sampleMsg, userId, "103", logLevel);
+
+
+        JsonArrayBuilder jsonArrayBuilder = Json.createArrayBuilder();
+        jsonArrayBuilder.add(testJson).add(testJson2).add(testJson3);
+        JsonArray returnedArray = jsonArrayBuilder.build();
+
+        List<LogData> processedArray = LogData.fromJson(returnedArray);
+
+        Assert.assertEquals(processedArray.size(), 3);
+        Assert.assertEquals(processedArray.get(0).getLogId(), "101");
+        Assert.assertEquals(processedArray.get(1).getLogId(), "102");
+        Assert.assertEquals(processedArray.get(2).getLogId(), "103");
     }
 
     @Test


### PR DESCRIPTION
- Adds steps to serialise JSON data / from a LogData class using GSON and associated unit tests
- Adds a first get at `/api/log` which returns all elements in the DB and a unit test for this

I plan on adding more endpoints in future PRs but don't want this to get too large.

To test:
- [ ] Ensure unit tests pass
- [ ] Code review