### PR TITLE
Adds a new enum called ServicesNames for the API

### DIFF
--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
@@ -18,6 +18,13 @@ import java.util.UUID;
  *
  */
 public class LogData {
+    private ServiceNames serviceName;
+    private String logId;
+    private Instant timestamp;
+    private LoggingLevels logLevel;
+    private String content;
+    private String userId;
+
     /**
      * Constructs a new LogData instance which represents a log or audit message
      * @param timestamp The time of the log message
@@ -25,13 +32,14 @@ public class LogData {
      * @param content The message content of this log entry
      * @param userId The user associated with this log entry
      */
-    public LogData(final Instant timestamp, final LoggingLevel logLevel,
-                   final String content, final String userId) {
+    public LogData(final Instant timestamp, final LoggingLevels logLevel,
+                   final String content, final String userId, final ServiceNames serviceName) {
         this.logId = UUID.randomUUID().toString();
         this.timestamp = timestamp;
         this.logLevel = logLevel;
         this.content = content;
         this.userId = userId;
+        this.serviceName = serviceName;
     }
 
     /**
@@ -44,9 +52,9 @@ public class LogData {
 
     /**
      * Returns the logging level of the underlying log message
-     * @return LoggingLevel enum with the current level
+     * @return LoggingLevels enum with the current level
      */
-    public LoggingLevel getLogLevel() {
+    public LoggingLevels getLogLevel() {
         return logLevel;
     }
 
@@ -76,6 +84,12 @@ public class LogData {
     }
 
     /**
+     * Returns the service which created this log
+     * @return ServiceName enum with the micro-service name
+     */
+    public ServiceNames getServiceName() { return serviceName; }
+
+    /**
      * Serialises the current object into a new JSON object
      * @return A json object for the current record
      */
@@ -85,7 +99,8 @@ public class LogData {
                .add("timestamp", this.timestamp.toString())
                .add("userId", this.userId)
                .add("logLevel", this.logLevel.toString())
-               .add("content", this.content);
+               .add("content", this.content)
+               .add("serviceName", this.serviceName.toString());
         return newJson.build();
     }
 
@@ -125,9 +140,5 @@ public class LogData {
 
     }
 
-    private String logId;
-    private Instant timestamp;
-    private LoggingLevel logLevel;
-    private String content;
-    private String userId;
+
 }

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LoggingLevels.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LoggingLevels.java
@@ -5,7 +5,7 @@ package uk.ac.aber.dcs.aberfitness.glados.db;
  * mechanisms. The order of precedence is:
  * Critical -> Error -> Warning -> Audit -> Info -> Debug
  */
-public enum LoggingLevel {
+public enum LoggingLevels {
 
     CRITICAL,
     ERROR,

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/ServiceNames.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/ServiceNames.java
@@ -1,0 +1,20 @@
+package uk.ac.aber.dcs.aberfitness.glados.db;
+
+/**
+ * Holds the names of all micro-services
+ * for the logging API
+ */
+public enum ServiceNames {
+    BOOKING_FACILITY,
+    CHALLENGES,
+    COMMUNICATIONS,
+    DEPLOYMENT,
+    FITBIT_INGEST,
+    GATEKEEPER,
+    GLADOS,
+    HEALTH_DASHBOARD,
+    HEALTH_DATA,
+    LADDERS,
+    USER_GROUPS
+
+}

--- a/src/test/java/LogApiTest.java
+++ b/src/test/java/LogApiTest.java
@@ -7,25 +7,25 @@ import org.mockito.MockitoAnnotations;
 import uk.ac.aber.dcs.aberfitness.glados.api.LogApi;
 import uk.ac.aber.dcs.aberfitness.glados.db.DatabaseConnection;
 import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
-import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevel;
+import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevels;
+import uk.ac.aber.dcs.aberfitness.glados.db.ServiceNames;
 
 import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonValue;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.notNull;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class LogApiTest {
-    @Mock
-    private DatabaseConnection dbMock;
+    @Mock private DatabaseConnection dbMock;
 
-    // Ensure we replace the injected concrete type with
-    @InjectMocks
-    private LogApi apiInstance;
+    // Ensure we replace the injected concrete type with the mock db connection
+    @InjectMocks private LogApi apiInstance;
 
     @Before
     public void setUp() {
@@ -33,18 +33,23 @@ public class LogApiTest {
         MockitoAnnotations.initMocks(this);
     }
 
+    private LogData createExampleLogData(){
+        return new LogData(Instant.now(), LoggingLevels.DEBUG, "TestContent",
+                "abc123", ServiceNames.GLADOS);
+    }
+
     @Test
     public void findAllCallReturnsAll() throws IOException {
-        LogData entryOne = new LogData(Instant.now(), LoggingLevel.DEBUG, "testContent", "abc123");
-        LogData entryTwo = new LogData(Instant.now(), LoggingLevel.WARNING, "testContent2", "xyz987");
+        LogData dummyLogOne = createExampleLogData();
+        LogData dummyLogTwo = createExampleLogData();
 
-        List<LogData> mockedData = Arrays.asList(entryOne, entryTwo);
-
+        List<LogData> mockedData = Arrays.asList(dummyLogOne, dummyLogOne);
         when(dbMock.getAllLogEntries()).thenReturn(mockedData);
 
         JsonArray returnedData = apiInstance.getAllEntries();
-
         Assert.assertEquals(mockedData, LogData.fromJson(returnedData));
     }
+
+
 
 }

--- a/src/test/java/LogDataTest.java
+++ b/src/test/java/LogDataTest.java
@@ -1,7 +1,8 @@
 import org.junit.Assert;
 import org.junit.Test;
 import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
-import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevel;
+import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevels;
+import uk.ac.aber.dcs.aberfitness.glados.db.ServiceNames;
 
 import javax.json.*;
 import java.time.Instant;
@@ -12,15 +13,17 @@ public class LogDataTest {
     public void LogDataGetters() {
         Instant now = Instant.now();
         String sampleMsg = "Hello world";
-        LoggingLevel logLevel = LoggingLevel.DEBUG;
+        LoggingLevels logLevel = LoggingLevels.DEBUG;
         String userId = "test123";
+        ServiceNames testName = ServiceNames.GLADOS;
 
-        final LogData testInstance = new LogData(now, logLevel, sampleMsg, userId);
+        final LogData testInstance = new LogData(now, logLevel, sampleMsg, userId, testName);
 
         Assert.assertEquals(testInstance.getTimestamp(), now);
         Assert.assertEquals(testInstance.getContent(), sampleMsg);
         Assert.assertEquals(testInstance.getLogLevel(), logLevel);
         Assert.assertEquals(testInstance.getUserId(), userId);
+        Assert.assertEquals(testInstance.getServiceName(), testName);
     }
 
     @Test
@@ -28,8 +31,10 @@ public class LogDataTest {
         Instant now = Instant.now();
 
         // Regardless of other fields the log id should always be unique
-        final LogData testInstanceOne = new LogData(now, LoggingLevel.DEBUG, "test", "id1");
-        final LogData testInstanceTwo = new LogData(now, LoggingLevel.DEBUG, "test", "id1");
+        final LogData testInstanceOne = new LogData(now, LoggingLevels.DEBUG,
+                "test", "id1", ServiceNames.GLADOS);
+        final LogData testInstanceTwo = new LogData(now, LoggingLevels.DEBUG,
+                "test", "id1", ServiceNames.GLADOS);
 
         Assert.assertNotEquals(testInstanceOne.getLogId(), testInstanceTwo.getLogId());
     }
@@ -38,10 +43,11 @@ public class LogDataTest {
     public void SerialisesToJsonCorrectly() {
         Instant now = Instant.now();
         String sampleMsg = "Hello world";
-        LoggingLevel logLevel = LoggingLevel.DEBUG;
+        LoggingLevels logLevel = LoggingLevels.DEBUG;
         String userId = "test123";
+        ServiceNames serviceName = ServiceNames.GLADOS;
 
-        final LogData testInstance = new LogData(now, logLevel, sampleMsg, userId);
+        final LogData testInstance = new LogData(now, logLevel, sampleMsg, userId, serviceName);
         JsonObject returnedJson = testInstance.toJson();
 
         Assert.assertNotEquals(returnedJson.getString("logId"), "");
@@ -49,10 +55,11 @@ public class LogDataTest {
         Assert.assertEquals(returnedJson.getString("userId"), userId);
         Assert.assertEquals(returnedJson.getString("logLevel"), logLevel.toString());
         Assert.assertEquals(returnedJson.getString("content"), sampleMsg);
+        Assert.assertEquals(returnedJson.getString("serviceName"), serviceName.toString());
     }
 
     private JsonObject createFakeJson(Instant time, String msg, String userId,
-                                      String logId, LoggingLevel logLevel){
+                                      String logId, LoggingLevels logLevel, ServiceNames serviceName) {
 
         JsonObjectBuilder newJsonObject = Json.createObjectBuilder();
 
@@ -61,7 +68,8 @@ public class LogDataTest {
                 .add("timestamp", time.toString())
                 .add("userId", userId)
                 .add("logLevel", logLevel.toString())
-                .add("content", msg);
+                .add("content", msg)
+                .add("serviceName", serviceName.toString());
         return newJsonObject.build();
     }
 
@@ -69,11 +77,12 @@ public class LogDataTest {
     public void SerialisesFromJsonCorrectly() {
         Instant now = Instant.now();
         String sampleMsg = "Hello world";
-        LoggingLevel logLevel = LoggingLevel.DEBUG;
+        LoggingLevels logLevel = LoggingLevels.DEBUG;
         String userId = "test123";
         String fakeId = "12345";
+        ServiceNames serviceName = ServiceNames.GLADOS;
 
-        JsonObject testJson = createFakeJson(now, sampleMsg, userId, fakeId, logLevel);
+        JsonObject testJson = createFakeJson(now, sampleMsg, userId, fakeId, logLevel, serviceName);
 
         LogData returnedClass = LogData.fromJson(testJson);
         Assert.assertEquals(returnedClass.getLogId(), fakeId);
@@ -84,15 +93,16 @@ public class LogDataTest {
     }
 
     @Test
-    public void SerialisesFromListCorrectly(){
+    public void SerialisesFromListCorrectly() {
         Instant now = Instant.now();
         String sampleMsg = "Hello world";
-        LoggingLevel logLevel = LoggingLevel.DEBUG;
+        LoggingLevels logLevel = LoggingLevels.DEBUG;
         String userId = "test123";
+        ServiceNames serviceName = ServiceNames.GLADOS;
 
-        JsonObject testJson = createFakeJson(now, sampleMsg, userId, "101", logLevel);
-        JsonObject testJson2 = createFakeJson(now, sampleMsg, userId, "102", logLevel);
-        JsonObject testJson3 = createFakeJson(now, sampleMsg, userId, "103", logLevel);
+        JsonObject testJson = createFakeJson(now, sampleMsg, userId, "101", logLevel, serviceName);
+        JsonObject testJson2 = createFakeJson(now, sampleMsg, userId, "102", logLevel, serviceName);
+        JsonObject testJson3 = createFakeJson(now, sampleMsg, userId, "103", logLevel, serviceName);
 
 
         JsonArrayBuilder jsonArrayBuilder = Json.createArrayBuilder();
@@ -111,10 +121,11 @@ public class LogDataTest {
     public void SerialisesSelfCorrectly() {
         Instant now = Instant.now();
         String sampleMsg = "Hello world";
-        LoggingLevel logLevel = LoggingLevel.DEBUG;
+        LoggingLevels logLevel = LoggingLevels.DEBUG;
         String userId = "test123";
+        ServiceNames serviceName = ServiceNames.GLADOS;
 
-        final LogData testInstance = new LogData(now, logLevel, sampleMsg, userId);
+        final LogData testInstance = new LogData(now, logLevel, sampleMsg, userId, serviceName);
 
         JsonObject returnedJson = testInstance.toJson();
         LogData returnedObject = LogData.fromJson(returnedJson);


### PR DESCRIPTION
This allows the caller to specify who the originator was, whilst ensuring we keep type safety with GSON. 
We should have put this in originally but alas I forgot

The next PR will build upon this to improve testability