### PR TITLE
Seperate json parsing from log data class

### DIFF
--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/GsonTimeDeserialiser.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/GsonTimeDeserialiser.java
@@ -4,7 +4,6 @@ import com.google.gson.*;
 
 import java.lang.reflect.Type;
 import java.time.Instant;
-import java.time.format.DateTimeFormatter;
 
 public class GsonTimeDeserialiser {
     public static final JsonDeserializer<Instant> INSTANT_DESERIALISER = new JsonDeserializer<Instant>() {

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/JsonParseExceptionWrapper.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/JsonParseExceptionWrapper.java
@@ -1,0 +1,20 @@
+package uk.ac.aber.dcs.aberfitness.glados.api;
+
+import com.google.gson.JsonParseException;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+
+
+/**
+ * Converts IOExceptions into InternalServer Error responses within the
+ * Javax Ws layer
+ */
+@Provider
+public class JsonParseExceptionWrapper implements ExceptionMapper<JsonParseException> {
+    @Override
+    public Response toResponse(JsonParseException exception) {
+        return Response.status(Response.Status.BAD_REQUEST).build();
+    }
+}

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/LogApi.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/LogApi.java
@@ -1,7 +1,9 @@
 package uk.ac.aber.dcs.aberfitness.glados.api;
 
 import uk.ac.aber.dcs.aberfitness.glados.db.DatabaseConnection;
+
 import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
+import uk.ac.aber.dcs.aberfitness.glados.db.LogDataJson;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
@@ -29,7 +31,9 @@ public class LogApi {
         // TODO add limits / ranges
         final JsonArrayBuilder jsonArray = Json.createArrayBuilder();
         List<LogData> foundEntries = dbConnection.getAllLogEntries();
-        foundEntries.forEach(e->jsonArray.add(e.toJson()));
+
+        // Ensure we have JSON serialisable elements
+        foundEntries.forEach(e->jsonArray.add(new LogDataJson(e).toJson()));
         return jsonArray.build();
     }
 

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
@@ -1,7 +1,11 @@
 package uk.ac.aber.dcs.aberfitness.glados.db;
 
+import java.lang.reflect.Field;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 /**
  * A class representing a log or audit entry. This class is marked abstract
@@ -109,6 +113,22 @@ public abstract class LogData {
                 && this.logLevel == other.logLevel && this.content.equals(other.content) &&
                 this.userId.equals(other.userId) && this.serviceName == other.serviceName;
 
+    }
+
+    public final boolean isValid() {
+        // GSON can return a log with all fields set to null
+        Field[] logDataFields = LogData.class.getDeclaredFields();
+
+        // We use reflection to check all fields of this class are not null
+        return Stream.of(logDataFields).allMatch(it -> {
+            try {
+                return it.get(this)!=null;
+            } catch (IllegalAccessException e) {
+                // Safety net in case reflection fails
+                e.printStackTrace();
+                return false;
+            }
+        });
     }
 
 

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
@@ -24,6 +24,7 @@ public abstract class LogData {
      * @param logLevel The level associated with this log message
      * @param content The message content of this log entry
      * @param userId The user associated with this log entry
+     * @param serviceName The service associated with this log entry
      */
     protected LogData(final Instant timestamp, final LoggingLevels logLevel,
                       final String content, final String userId, final ServiceNames serviceName) {
@@ -96,6 +97,13 @@ public abstract class LogData {
      */
     public ServiceNames getServiceName() { return serviceName; }
 
+    /**
+     * Overrides and implements the equality operator for LogData objects.
+     * This is marked final as deriving classes should only serialise
+     * not implement operators and is agnostic of the serialising method.
+     * @param obj The object to compare to
+     * @return If all fields are equal, else false
+     */
     @Override
     public final boolean equals(Object obj) {
         if (obj == null){
@@ -124,6 +132,11 @@ public abstract class LogData {
     }
 
 
+    /**
+     * Returns if all the data fields within LogData are populated
+     * and not null. If any fields are null a false is returned
+     * @return True if all fields are populated, else false
+     */
     public final boolean isValid() {
         // GSON can return a log with all fields set to null
         Field[] logDataFields = LogData.class.getDeclaredFields();

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
@@ -2,8 +2,6 @@ package uk.ac.aber.dcs.aberfitness.glados.db;
 
 import java.lang.reflect.Field;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -114,6 +112,17 @@ public abstract class LogData {
                 this.userId.equals(other.userId) && this.serviceName == other.serviceName;
 
     }
+
+    /**
+     * A protected setter for serialisers which use reflection to set fields
+     * such as GSON. This allows the caller to ask the underlying struct
+     * to set a new UUID which would normally be done in the constructor.
+     * This call is package-private.
+     */
+    void generateLogId(){
+        this.logId = UUID.randomUUID().toString();
+    }
+
 
     public final boolean isValid() {
         // GSON can return a log with all fields set to null

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogData.java
@@ -1,23 +1,14 @@
 package uk.ac.aber.dcs.aberfitness.glados.db;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import uk.ac.aber.dcs.aberfitness.glados.api.GsonTimeDeserialiser;
-
-import javax.json.Json;
-import javax.json.JsonArray;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 
 /**
- * A class representing a log or audit entry.
- *
+ * A class representing a log or audit entry. This class is marked abstract
+ * to force extending classes to implement to X serialisation. For example
+ * toJson in the LogDataJson class
  */
-public class LogData {
+public abstract class LogData {
     private ServiceNames serviceName;
     private String logId;
     private Instant timestamp;
@@ -32,14 +23,28 @@ public class LogData {
      * @param content The message content of this log entry
      * @param userId The user associated with this log entry
      */
-    public LogData(final Instant timestamp, final LoggingLevels logLevel,
-                   final String content, final String userId, final ServiceNames serviceName) {
+    protected LogData(final Instant timestamp, final LoggingLevels logLevel,
+                      final String content, final String userId, final ServiceNames serviceName) {
         this.logId = UUID.randomUUID().toString();
         this.timestamp = timestamp;
         this.logLevel = logLevel;
         this.content = content;
         this.userId = userId;
         this.serviceName = serviceName;
+    }
+
+    /**
+     * Implements a copy constructor which is invoked when switching
+     * the outer serialisation methods by the extending class
+     * @param other The existing LogData to copy
+     */
+    protected LogData(LogData other){
+        this.logId = other.logId;
+        this.timestamp = other.timestamp;
+        this.logLevel = other.logLevel;
+        this.content = other.content;
+        this.userId = other.userId;
+        this.serviceName = other.serviceName;
     }
 
     /**
@@ -89,42 +94,8 @@ public class LogData {
      */
     public ServiceNames getServiceName() { return serviceName; }
 
-    /**
-     * Serialises the current object into a new JSON object
-     * @return A json object for the current record
-     */
-    public JsonObject toJson(){
-        JsonObjectBuilder newJson = Json.createObjectBuilder();
-        newJson.add("logId", this.logId)
-               .add("timestamp", this.timestamp.toString())
-               .add("userId", this.userId)
-               .add("logLevel", this.logLevel.toString())
-               .add("content", this.content)
-               .add("serviceName", this.serviceName.toString());
-        return newJson.build();
-    }
-
-    public static LogData fromJson(JsonObject jsonObject){
-        GsonBuilder gsonBuilder = new GsonBuilder();
-        // Register a custom adaptor to convert to instant from strings
-        gsonBuilder.registerTypeAdapter(Instant.class, GsonTimeDeserialiser.INSTANT_DESERIALISER);
-
-        Gson gson = gsonBuilder.create();
-        return gson.fromJson(jsonObject.toString(), LogData.class);
-    }
-
-    public static List<LogData> fromJson(JsonArray jsonArray){
-        GsonBuilder gsonBuilder = new GsonBuilder();
-        // Register a custom adaptor to convert to instant from strings
-        gsonBuilder.registerTypeAdapter(Instant.class, GsonTimeDeserialiser.INSTANT_DESERIALISER);
-
-        Gson gson = gsonBuilder.create();
-        LogData[] converted = gson.fromJson(jsonArray.toString(), LogData[].class);
-        return Arrays.asList(converted);
-    }
-
     @Override
-    public boolean equals(Object obj) {
+    public final boolean equals(Object obj) {
         if (obj == null){
             return false;
         }
@@ -136,7 +107,7 @@ public class LogData {
         final LogData other = (LogData) obj;
         return this.logId.equals(other.logId) && this.timestamp.equals(other.timestamp)
                 && this.logLevel == other.logLevel && this.content.equals(other.content) &&
-                this.userId.equals(other.userId);
+                this.userId.equals(other.userId) && this.serviceName == other.serviceName;
 
     }
 

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataJson.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataJson.java
@@ -23,6 +23,7 @@ public class LogDataJson extends LogData {
      * @param logLevel The level associated with this log message
      * @param content The message content of this log entry
      * @param userId The user associated with this log entry
+     * @param serviceName The micro-service associated with this log entry
      */
     public LogDataJson(final Instant timestamp, final LoggingLevels logLevel,
                           final String content, final String userId, final ServiceNames serviceName){
@@ -54,6 +55,13 @@ public class LogDataJson extends LogData {
         return newJson.build();
     }
 
+    /**
+     * Serialises from a single JSON object into a LogDataJson
+     * object, which implements LogData
+     * @param jsonObject The JSON representing the LogDataObject
+     * @return LogDataJson object for the log entry
+     * @throws JsonParseException If all fields are not present and valid
+     */
     public static LogDataJson fromJson(JsonObject jsonObject) throws JsonParseException {
         GsonBuilder gsonBuilder = new GsonBuilder();
         // Register a custom adaptor to convert to instant from strings
@@ -70,6 +78,13 @@ public class LogDataJson extends LogData {
         return returnedObj;
     }
 
+    /**
+     * Serialises from multiple JSON Objects into a list of LogDataJson
+     * objects, all of which implement LogData
+     * @param jsonArray The array containing JSON arrays
+     * @return List of LogData objects
+     * @throws JsonParseException If any LogData objects are invalid or there are none present
+     */
     public static List<LogDataJson> fromJson(JsonArray jsonArray) throws JsonParseException{
         GsonBuilder gsonBuilder = new GsonBuilder();
         // Register a custom adaptor to convert to instant from strings
@@ -82,7 +97,7 @@ public class LogDataJson extends LogData {
         boolean allValid = Stream.of(converted).allMatch(LogData::isValid);
 
         if (converted.length == 0 || !allValid){
-            throw new JsonParseException("Partial or empty JSON was received");
+            throw new JsonParseException("Partial, invalid or empty JSON array was received");
         }
 
         return Arrays.asList(converted);

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataJson.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataJson.java
@@ -1,0 +1,73 @@
+package uk.ac.aber.dcs.aberfitness.glados.db;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import uk.ac.aber.dcs.aberfitness.glados.api.GsonTimeDeserialiser;
+
+import javax.json.Json;
+import javax.json.JsonArray;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+public class LogDataJson extends LogData {
+
+    /**
+     * Constructs a new LogDataJson instance which implements a
+     * JSON serialiser for the underlying class
+     * @param timestamp The time of the log message
+     * @param logLevel The level associated with this log message
+     * @param content The message content of this log entry
+     * @param userId The user associated with this log entry
+     */
+    public LogDataJson(final Instant timestamp, final LoggingLevels logLevel,
+                          final String content, final String userId, final ServiceNames serviceName){
+        super(timestamp, logLevel, content, userId, serviceName);
+    }
+
+    /**
+     * Constructs a new LogDataJson from a differing serialising implementation
+     * to a JSON serialiser
+     * @param existingLogData An existing differing type of serialising JSON
+     */
+    public LogDataJson(LogData existingLogData){
+        super(existingLogData);
+    }
+
+
+    /**
+     * Serialises the current object into a new JSON object
+     * @return A json object for the current record
+     */
+    public JsonObject toJson(){
+        JsonObjectBuilder newJson = Json.createObjectBuilder();
+        newJson.add("logId", getLogId())
+                .add("timestamp", getTimestamp().toString())
+                .add("userId", getUserId())
+                .add("logLevel", getLogLevel().toString())
+                .add("content", getContent())
+                .add("serviceName", getServiceName().toString());
+        return newJson.build();
+    }
+
+    public static LogDataJson fromJson(JsonObject jsonObject){
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        // Register a custom adaptor to convert to instant from strings
+        gsonBuilder.registerTypeAdapter(Instant.class, GsonTimeDeserialiser.INSTANT_DESERIALISER);
+
+        Gson gson = gsonBuilder.create();
+        return gson.fromJson(jsonObject.toString(), LogDataJson.class);
+    }
+
+    public static List<LogDataJson> fromJson(JsonArray jsonArray){
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        // Register a custom adaptor to convert to instant from strings
+        gsonBuilder.registerTypeAdapter(Instant.class, GsonTimeDeserialiser.INSTANT_DESERIALISER);
+
+        Gson gson = gsonBuilder.create();
+        LogDataJson[] converted = gson.fromJson(jsonArray.toString(), LogDataJson[].class);
+        return Arrays.asList(converted);
+    }
+}

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataJson.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataJson.java
@@ -61,6 +61,7 @@ public class LogDataJson extends LogData {
 
         Gson gson = gsonBuilder.create();
         LogDataJson returnedObj = gson.fromJson(jsonObject.toString(), LogDataJson.class);
+        returnedObj.generateLogId();
 
         if (!returnedObj.isValid()){
             throw new JsonParseException("Partial or empty JSON was received");
@@ -76,6 +77,7 @@ public class LogDataJson extends LogData {
 
         Gson gson = gsonBuilder.create();
         LogDataJson[] converted = gson.fromJson(jsonArray.toString(), LogDataJson[].class);
+        Stream.of(converted).forEach(LogData::generateLogId);
 
         boolean allValid = Stream.of(converted).allMatch(LogData::isValid);
 

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataNoSerial.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataNoSerial.java
@@ -10,6 +10,11 @@ import java.time.Instant;
 public class LogDataNoSerial extends LogData {
     /**
      * Creates a new LogDataNoSerial class with the specified data
+     * @param timestamp The time of the log message
+     * @param logLevel The level associated with this log message
+     * @param content The message content of this log entry
+     * @param userId The user associated with this log entry
+     * @param serviceName The service associated with this log entry
      */
     public LogDataNoSerial(final Instant timestamp, final LoggingLevels logLevel,
                            final String content, final String userId, final ServiceNames serviceName){
@@ -19,6 +24,7 @@ public class LogDataNoSerial extends LogData {
     /**
      * Converts an existing LogDataX class which can serialise into
      * a class which only holds data
+     * @param other An instance of LogData or deriving type to convert from
      */
     public LogDataNoSerial(LogData other){
         super(other);

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataNoSerial.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataNoSerial.java
@@ -1,0 +1,30 @@
+package uk.ac.aber.dcs.aberfitness.glados.db;
+
+import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
+import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevels;
+import uk.ac.aber.dcs.aberfitness.glados.db.ServiceNames;
+
+import java.time.Instant;
+
+/**
+ * A class which is the equivalent of a plain struct
+ * This can be converted to any other serialisable format
+ * by constructing the required format
+ */
+public class LogDataNoSerial extends LogData {
+    /**
+     * Creates a new LogDataNoSerial class with the specified data
+     */
+    public LogDataNoSerial(final Instant timestamp, final LoggingLevels logLevel,
+                           final String content, final String userId, final ServiceNames serviceName){
+        super(timestamp, logLevel, content, userId, serviceName);
+    }
+
+    /**
+     * Converts an existing LogDataX class which can serialise into
+     * a class which only holds data
+     */
+    public LogDataNoSerial(LogData other){
+        super(other);
+    }
+}

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataNoSerial.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/LogDataNoSerial.java
@@ -1,9 +1,5 @@
 package uk.ac.aber.dcs.aberfitness.glados.db;
 
-import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
-import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevels;
-import uk.ac.aber.dcs.aberfitness.glados.db.ServiceNames;
-
 import java.time.Instant;
 
 /**

--- a/src/test/java/LogApiTest.java
+++ b/src/test/java/LogApiTest.java
@@ -5,10 +5,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import uk.ac.aber.dcs.aberfitness.glados.api.LogApi;
-import uk.ac.aber.dcs.aberfitness.glados.db.DatabaseConnection;
-import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
-import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevels;
-import uk.ac.aber.dcs.aberfitness.glados.db.ServiceNames;
+import uk.ac.aber.dcs.aberfitness.glados.db.*;
 
 import javax.json.JsonArray;
 import java.io.IOException;
@@ -34,7 +31,7 @@ public class LogApiTest {
     }
 
     private LogData createExampleLogData(){
-        return new LogData(Instant.now(), LoggingLevels.DEBUG, "TestContent",
+        return new LogDataNoSerial(Instant.now(), LoggingLevels.DEBUG, "TestContent",
                 "abc123", ServiceNames.GLADOS);
     }
 
@@ -43,11 +40,12 @@ public class LogApiTest {
         LogData dummyLogOne = createExampleLogData();
         LogData dummyLogTwo = createExampleLogData();
 
-        List<LogData> mockedData = Arrays.asList(dummyLogOne, dummyLogOne);
+        List<LogData> mockedData = Arrays.asList(dummyLogOne, dummyLogTwo);
         when(dbMock.getAllLogEntries()).thenReturn(mockedData);
 
+        // This should return JSON
         JsonArray returnedData = apiInstance.getAllEntries();
-        Assert.assertEquals(mockedData, LogData.fromJson(returnedData));
+        Assert.assertEquals(mockedData, LogDataJson.fromJson(returnedData));
     }
 
 

--- a/src/test/java/LogApiTest.java
+++ b/src/test/java/LogApiTest.java
@@ -30,6 +30,10 @@ public class LogApiTest {
         MockitoAnnotations.initMocks(this);
     }
 
+    /**
+     * Returns a sample LogData entry for unit testing
+     * @return A sample LogData object
+     */
     private LogData createExampleLogData() {
         return new LogDataNoSerial(Instant.now(), LoggingLevels.DEBUG, "TestContent",
                 "abc123", ServiceNames.GLADOS);

--- a/src/test/java/LogApiTest.java
+++ b/src/test/java/LogApiTest.java
@@ -55,4 +55,6 @@ public class LogApiTest {
     }
 
 
+
+
 }

--- a/src/test/java/LogApiTest.java
+++ b/src/test/java/LogApiTest.java
@@ -1,3 +1,4 @@
+import helpers.LogDataHelpers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,16 +14,15 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.notNull;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class LogApiTest {
-    @Mock private DatabaseConnection dbMock;
+    @Mock
+    private DatabaseConnection dbMock;
 
     // Ensure we replace the injected concrete type with the mock db connection
-    @InjectMocks private LogApi apiInstance;
+    @InjectMocks
+    private LogApi apiInstance;
 
     @Before
     public void setUp() {
@@ -30,7 +30,7 @@ public class LogApiTest {
         MockitoAnnotations.initMocks(this);
     }
 
-    private LogData createExampleLogData(){
+    private LogData createExampleLogData() {
         return new LogDataNoSerial(Instant.now(), LoggingLevels.DEBUG, "TestContent",
                 "abc123", ServiceNames.GLADOS);
     }
@@ -44,10 +44,15 @@ public class LogApiTest {
         when(dbMock.getAllLogEntries()).thenReturn(mockedData);
 
         // This should return JSON
-        JsonArray returnedData = apiInstance.getAllEntries();
-        Assert.assertEquals(mockedData, LogDataJson.fromJson(returnedData));
-    }
+        JsonArray returnedJson = apiInstance.getAllEntries();
+        List<LogDataJson> returnedEntries = LogDataJson.fromJson(returnedJson);
 
+        Assert.assertEquals(returnedEntries.size(), mockedData.size());
+
+        for (int i = 0; i < returnedEntries.size(); i++) {
+            LogDataHelpers.isAlmostEqual(returnedEntries.get(i), mockedData.get(i));
+        }
+    }
 
 
 }

--- a/src/test/java/LogDataJsonTest.java
+++ b/src/test/java/LogDataJsonTest.java
@@ -1,3 +1,4 @@
+import com.google.gson.JsonParseException;
 import org.junit.Assert;
 import org.junit.Test;
 import uk.ac.aber.dcs.aberfitness.glados.db.LogDataNoSerial;
@@ -8,6 +9,8 @@ import uk.ac.aber.dcs.aberfitness.glados.db.ServiceNames;
 import javax.json.*;
 import java.time.Instant;
 import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class LogDataJsonTest {
     private JsonObject createFakeJson(Instant time, String msg, String userId,
@@ -115,6 +118,28 @@ public class LogDataJsonTest {
 
         Assert.assertEquals(returnedObject, testInstance);
     }
-    
+
+
+    @Test
+    public void JsonParseExceptionIsThrownForBlank() {
+        JsonObject blankObj = Json.createObjectBuilder().build();
+        JsonArray blankArray = Json.createArrayBuilder().build();
+
+        assertThrows(JsonParseException.class, ()-> { LogDataJson.fromJson(blankObj); });
+        assertThrows(JsonParseException.class, ()-> { LogDataJson.fromJson(blankArray); });
+
+    }
+
+    @Test
+    public void JsonParseExceptionIsThrownForPartial(){
+        JsonObjectBuilder partialObj = Json.createObjectBuilder();
+        partialObj.add("logId", "123");
+        partialObj.add("timestamp", Instant.now().toString());
+
+        JsonObject partialJson = partialObj.build();
+
+        assertThrows(JsonParseException.class, () -> {LogDataJson.fromJson(partialJson);});
+    }
+
     
 }

--- a/src/test/java/LogDataJsonTest.java
+++ b/src/test/java/LogDataJsonTest.java
@@ -1,0 +1,120 @@
+import org.junit.Assert;
+import org.junit.Test;
+import uk.ac.aber.dcs.aberfitness.glados.db.LogDataNoSerial;
+import uk.ac.aber.dcs.aberfitness.glados.db.LogDataJson;
+import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevels;
+import uk.ac.aber.dcs.aberfitness.glados.db.ServiceNames;
+
+import javax.json.*;
+import java.time.Instant;
+import java.util.List;
+
+public class LogDataJsonTest {
+    private JsonObject createFakeJson(Instant time, String msg, String userId,
+                                      String logId, LoggingLevels logLevel, ServiceNames serviceName) {
+
+        JsonObjectBuilder newJsonObject = Json.createObjectBuilder();
+
+
+        newJsonObject.add("logId", logId)
+                .add("timestamp", time.toString())
+                .add("userId", userId)
+                .add("logLevel", logLevel.toString())
+                .add("content", msg)
+                .add("serviceName", serviceName.toString());
+        return newJsonObject.build();
+    }
+
+    @Test
+    public void ConvertsFromOtherSerialisingTypeCorrectly(){
+        LogDataNoSerial noSerial = new LogDataNoSerial(Instant.now(), LoggingLevels.DEBUG,
+                "test", "abc123", ServiceNames.GLADOS);
+
+        LogDataJson convertedInstance = new LogDataJson(noSerial);
+        Assert.assertNotNull(convertedInstance);
+
+        // These are equiv if converted correctly
+        Assert.assertEquals(noSerial.getLogId(), convertedInstance.getLogId());
+    }
+
+    @Test
+    public void SerialisesToJsonCorrectly() {
+        Instant now = Instant.now();
+        String sampleMsg = "Hello world";
+        LoggingLevels logLevel = LoggingLevels.DEBUG;
+        String userId = "test123";
+        ServiceNames serviceName = ServiceNames.GLADOS;
+
+        final LogDataJson testInstance = new LogDataJson(now, logLevel, sampleMsg, userId, serviceName);
+        JsonObject returnedJson = testInstance.toJson();
+
+        Assert.assertNotEquals(returnedJson.getString("logId"), "");
+        Assert.assertEquals(returnedJson.getString("timestamp"), now.toString());
+        Assert.assertEquals(returnedJson.getString("userId"), userId);
+        Assert.assertEquals(returnedJson.getString("logLevel"), logLevel.toString());
+        Assert.assertEquals(returnedJson.getString("content"), sampleMsg);
+        Assert.assertEquals(returnedJson.getString("serviceName"), serviceName.toString());
+    }
+
+    @Test
+    public void SerialisesFromJsonCorrectly() {
+        Instant now = Instant.now();
+        String sampleMsg = "Hello world";
+        LoggingLevels logLevel = LoggingLevels.DEBUG;
+        String userId = "test123";
+        String fakeId = "12345";
+        ServiceNames serviceName = ServiceNames.GLADOS;
+
+        JsonObject testJson = createFakeJson(now, sampleMsg, userId, fakeId, logLevel, serviceName);
+
+        LogDataJson returnedClass = LogDataJson.fromJson(testJson);
+        Assert.assertEquals(returnedClass.getLogId(), fakeId);
+        Assert.assertEquals(returnedClass.getUserId(), userId);
+        Assert.assertEquals(returnedClass.getLogLevel(), logLevel);
+        Assert.assertEquals(returnedClass.getContent(), sampleMsg);
+        Assert.assertEquals(returnedClass.getTimestamp(), now);
+    }
+
+    @Test
+    public void SerialisesFromListCorrectly() {
+        Instant now = Instant.now();
+        String sampleMsg = "Hello world";
+        LoggingLevels logLevel = LoggingLevels.DEBUG;
+        String userId = "test123";
+        ServiceNames serviceName = ServiceNames.GLADOS;
+
+        JsonObject testJson = createFakeJson(now, sampleMsg, userId, "101", logLevel, serviceName);
+        JsonObject testJson2 = createFakeJson(now, sampleMsg, userId, "102", logLevel, serviceName);
+        JsonObject testJson3 = createFakeJson(now, sampleMsg, userId, "103", logLevel, serviceName);
+
+
+        JsonArrayBuilder jsonArrayBuilder = Json.createArrayBuilder();
+        jsonArrayBuilder.add(testJson).add(testJson2).add(testJson3);
+        JsonArray returnedArray = jsonArrayBuilder.build();
+
+        List<LogDataJson> processedArray = LogDataJson.fromJson(returnedArray);
+
+        Assert.assertEquals(processedArray.size(), 3);
+        Assert.assertEquals(processedArray.get(0).getLogId(), "101");
+        Assert.assertEquals(processedArray.get(1).getLogId(), "102");
+        Assert.assertEquals(processedArray.get(2).getLogId(), "103");
+    }
+
+    @Test
+    public void SerialisesSelfCorrectly() {
+        Instant now = Instant.now();
+        String sampleMsg = "Hello world";
+        LoggingLevels logLevel = LoggingLevels.DEBUG;
+        String userId = "test123";
+        ServiceNames serviceName = ServiceNames.GLADOS;
+
+        final LogDataJson testInstance = new LogDataJson(now, logLevel, sampleMsg, userId, serviceName);
+
+        JsonObject returnedJson = testInstance.toJson();
+        LogDataJson returnedObject = LogDataJson.fromJson(returnedJson);
+
+        Assert.assertEquals(returnedObject, testInstance);
+    }
+    
+    
+}

--- a/src/test/java/LogDataTest.java
+++ b/src/test/java/LogDataTest.java
@@ -1,12 +1,11 @@
 import org.junit.Assert;
 import org.junit.Test;
+import uk.ac.aber.dcs.aberfitness.glados.db.LogDataNoSerial;
 import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
 import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevels;
 import uk.ac.aber.dcs.aberfitness.glados.db.ServiceNames;
 
-import javax.json.*;
 import java.time.Instant;
-import java.util.List;
 
 public class LogDataTest {
     @Test
@@ -17,7 +16,7 @@ public class LogDataTest {
         String userId = "test123";
         ServiceNames testName = ServiceNames.GLADOS;
 
-        final LogData testInstance = new LogData(now, logLevel, sampleMsg, userId, testName);
+        final LogData testInstance = new LogDataNoSerial(now, logLevel, sampleMsg, userId, testName);
 
         Assert.assertEquals(testInstance.getTimestamp(), now);
         Assert.assertEquals(testInstance.getContent(), sampleMsg);
@@ -31,108 +30,14 @@ public class LogDataTest {
         Instant now = Instant.now();
 
         // Regardless of other fields the log id should always be unique
-        final LogData testInstanceOne = new LogData(now, LoggingLevels.DEBUG,
+        final LogData testInstanceOne = new LogDataNoSerial(now, LoggingLevels.DEBUG,
                 "test", "id1", ServiceNames.GLADOS);
-        final LogData testInstanceTwo = new LogData(now, LoggingLevels.DEBUG,
+        final LogData testInstanceTwo = new LogDataNoSerial(now, LoggingLevels.DEBUG,
                 "test", "id1", ServiceNames.GLADOS);
 
         Assert.assertNotEquals(testInstanceOne.getLogId(), testInstanceTwo.getLogId());
     }
 
-    @Test
-    public void SerialisesToJsonCorrectly() {
-        Instant now = Instant.now();
-        String sampleMsg = "Hello world";
-        LoggingLevels logLevel = LoggingLevels.DEBUG;
-        String userId = "test123";
-        ServiceNames serviceName = ServiceNames.GLADOS;
-
-        final LogData testInstance = new LogData(now, logLevel, sampleMsg, userId, serviceName);
-        JsonObject returnedJson = testInstance.toJson();
-
-        Assert.assertNotEquals(returnedJson.getString("logId"), "");
-        Assert.assertEquals(returnedJson.getString("timestamp"), now.toString());
-        Assert.assertEquals(returnedJson.getString("userId"), userId);
-        Assert.assertEquals(returnedJson.getString("logLevel"), logLevel.toString());
-        Assert.assertEquals(returnedJson.getString("content"), sampleMsg);
-        Assert.assertEquals(returnedJson.getString("serviceName"), serviceName.toString());
-    }
-
-    private JsonObject createFakeJson(Instant time, String msg, String userId,
-                                      String logId, LoggingLevels logLevel, ServiceNames serviceName) {
-
-        JsonObjectBuilder newJsonObject = Json.createObjectBuilder();
-
-
-        newJsonObject.add("logId", logId)
-                .add("timestamp", time.toString())
-                .add("userId", userId)
-                .add("logLevel", logLevel.toString())
-                .add("content", msg)
-                .add("serviceName", serviceName.toString());
-        return newJsonObject.build();
-    }
-
-    @Test
-    public void SerialisesFromJsonCorrectly() {
-        Instant now = Instant.now();
-        String sampleMsg = "Hello world";
-        LoggingLevels logLevel = LoggingLevels.DEBUG;
-        String userId = "test123";
-        String fakeId = "12345";
-        ServiceNames serviceName = ServiceNames.GLADOS;
-
-        JsonObject testJson = createFakeJson(now, sampleMsg, userId, fakeId, logLevel, serviceName);
-
-        LogData returnedClass = LogData.fromJson(testJson);
-        Assert.assertEquals(returnedClass.getLogId(), fakeId);
-        Assert.assertEquals(returnedClass.getUserId(), userId);
-        Assert.assertEquals(returnedClass.getLogLevel(), logLevel);
-        Assert.assertEquals(returnedClass.getContent(), sampleMsg);
-        Assert.assertEquals(returnedClass.getTimestamp(), now);
-    }
-
-    @Test
-    public void SerialisesFromListCorrectly() {
-        Instant now = Instant.now();
-        String sampleMsg = "Hello world";
-        LoggingLevels logLevel = LoggingLevels.DEBUG;
-        String userId = "test123";
-        ServiceNames serviceName = ServiceNames.GLADOS;
-
-        JsonObject testJson = createFakeJson(now, sampleMsg, userId, "101", logLevel, serviceName);
-        JsonObject testJson2 = createFakeJson(now, sampleMsg, userId, "102", logLevel, serviceName);
-        JsonObject testJson3 = createFakeJson(now, sampleMsg, userId, "103", logLevel, serviceName);
-
-
-        JsonArrayBuilder jsonArrayBuilder = Json.createArrayBuilder();
-        jsonArrayBuilder.add(testJson).add(testJson2).add(testJson3);
-        JsonArray returnedArray = jsonArrayBuilder.build();
-
-        List<LogData> processedArray = LogData.fromJson(returnedArray);
-
-        Assert.assertEquals(processedArray.size(), 3);
-        Assert.assertEquals(processedArray.get(0).getLogId(), "101");
-        Assert.assertEquals(processedArray.get(1).getLogId(), "102");
-        Assert.assertEquals(processedArray.get(2).getLogId(), "103");
-    }
-
-    @Test
-    public void SerialisesSelfCorrectly() {
-        Instant now = Instant.now();
-        String sampleMsg = "Hello world";
-        LoggingLevels logLevel = LoggingLevels.DEBUG;
-        String userId = "test123";
-        ServiceNames serviceName = ServiceNames.GLADOS;
-
-        final LogData testInstance = new LogData(now, logLevel, sampleMsg, userId, serviceName);
-
-        JsonObject returnedJson = testInstance.toJson();
-        LogData returnedObject = LogData.fromJson(returnedJson);
-
-        Assert.assertEquals(returnedObject, testInstance);
-
-    }
 
 
 }

--- a/src/test/java/LogDataTest.java
+++ b/src/test/java/LogDataTest.java
@@ -38,6 +38,16 @@ public class LogDataTest {
         Assert.assertNotEquals(testInstanceOne.getLogId(), testInstanceTwo.getLogId());
     }
 
+    @Test
+    public void LogDataCopyConstructor(){
+        final LogData testInstanceOne = new LogDataNoSerial(Instant.now(), LoggingLevels.DEBUG,
+                "test", "id1", ServiceNames.GLADOS);
+
+        final LogData testInstanceTwo = new LogDataNoSerial(testInstanceOne);
+
+        Assert.assertEquals(testInstanceOne, testInstanceTwo);
+    }
+
 
 
 }

--- a/src/test/java/helpers/LogDataHelpers.java
+++ b/src/test/java/helpers/LogDataHelpers.java
@@ -1,0 +1,18 @@
+package helpers;
+
+import org.junit.Assert;
+import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
+
+public class LogDataHelpers {
+    /**
+     * Compares all fields except UUID which cannot be set through JSON
+     */
+    static public void isAlmostEqual(LogData one, LogData two){
+        Assert.assertEquals(one.getUserId(), two.getUserId());
+        Assert.assertEquals(one.getLogLevel(), two.getLogLevel());
+        Assert.assertEquals(one.getContent(), two.getContent());
+        Assert.assertEquals(one.getTimestamp(), two.getTimestamp());
+
+        Assert.assertNotEquals(one.getLogId(), two.getLogLevel());
+    }
+}


### PR DESCRIPTION
This PR contains the following:
- Separate the POD structure containing log data from the serialisation method
- Make various serialising methods convertible (this means at a later date the client could easily extend the class to make it XML serialisable)
- Handle GSON bypassing our constructor and putting nulls in from the JSON by using reflection to check the fields
- Handle the `JSONParseException` as a status code
- Remove the log id as a JSON field (we generate them, doh)
- More unit tests :D 

Fixes: #5 

In a future PR:
- Add a method of testing the REST API responses directly (probably using a lib)
- Test our handling of both good/bad JSON at the integration level