### PR TITLE
Rename Log* to Audit*

### DIFF
--- a/glados.iml
+++ b/glados.iml
@@ -39,6 +39,34 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax:javaee-api:8.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.sun.mail:javax.mail:1.6.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.activation:activation:1.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.junit:arquillian-junit-container:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.junit:arquillian-junit-core:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.test:arquillian-test-api:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.core:arquillian-core-api:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.test:arquillian-test-spi:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.core:arquillian-core-spi:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.container:arquillian-container-test-api:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.shrinkwrap:shrinkwrap-api:1.2.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-api-base:2.0.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.container:arquillian-container-test-spi:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.core:arquillian-core-impl-base:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.test:arquillian-test-impl-base:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.container:arquillian-container-impl-base:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.config:arquillian-config-api:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.config:arquillian-config-impl-base:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.config:arquillian-config-spi:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.shrinkwrap.descriptors:shrinkwrap-descriptors-spi:2.0.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.container:arquillian-container-test-impl-base:1.4.1.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.shrinkwrap:shrinkwrap-impl-base:1.2.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.shrinkwrap:shrinkwrap-spi:1.2.6" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: fish.payara.arquillian:arquillian-payara-server-4-embedded:1.0.Beta3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.container:arquillian-container-spi:1.1.13.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.protocol:arquillian-protocol-servlet:1.1.13.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.testenricher:arquillian-testenricher-cdi:1.1.13.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.testenricher:arquillian-testenricher-ejb:1.1.13.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.testenricher:arquillian-testenricher-resource:1.1.13.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.jboss.arquillian.testenricher:arquillian-testenricher-initialcontext:1.1.13.Final" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: fish.payara.extras:payara-embedded-all:5.183" level="project" />
     <orderEntry type="library" name="Maven: javax.json:javax.json-api:1.1" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish:javax.json:1.1" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.5" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,6 @@
     </properties>
 
     <dependencies>
-        <!-- Junit -->
         <dependency>
             <!-- Java EE REST API-->
             <groupId>javax</groupId>
@@ -23,6 +22,42 @@
             <version>8.0</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- Arquillian -->
+
+        <dependency>
+            <groupId>org.jboss.arquillian</groupId>
+            <artifactId>arquillian-bom</artifactId>
+            <version>1.1.14.Final</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+            <version>1.4.1.Final</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Payara Unit testing Instance -->
+        <dependency>
+            <groupId>fish.payara.arquillian</groupId>
+            <artifactId>arquillian-payara-server-4-embedded</artifactId>
+            <version>1.0.Beta3</version>
+            <scope>test</scope>
+
+        </dependency>
+
+        <dependency>
+            <groupId>fish.payara.extras</groupId>
+            <artifactId>payara-embedded-all</artifactId>
+            <version>5.183</version>
+            <scope>test</scope>
+
+        </dependency>
+
+
 
         <!-- JSON Parsing -->
         <dependency>
@@ -44,6 +79,7 @@
             <version>2.8.5</version>
         </dependency>
 
+        <!-- Junit -->
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/AuditApi.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/api/AuditApi.java
@@ -1,9 +1,8 @@
 package uk.ac.aber.dcs.aberfitness.glados.api;
 
+import uk.ac.aber.dcs.aberfitness.glados.db.AuditData;
+import uk.ac.aber.dcs.aberfitness.glados.db.AuditDataJson;
 import uk.ac.aber.dcs.aberfitness.glados.db.DatabaseConnection;
-
-import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
-import uk.ac.aber.dcs.aberfitness.glados.db.LogDataJson;
 
 import javax.ejb.Stateless;
 import javax.inject.Inject;
@@ -22,7 +21,7 @@ import java.util.List;
 @Path("log")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
-public class LogApi {
+public class AuditApi {
     @Inject
     DatabaseConnection dbConnection;
 
@@ -30,10 +29,10 @@ public class LogApi {
     public JsonArray getAllEntries() throws IOException {
         // TODO add limits / ranges
         final JsonArrayBuilder jsonArray = Json.createArrayBuilder();
-        List<LogData> foundEntries = dbConnection.getAllLogEntries();
+        List<AuditData> foundEntries = dbConnection.getAllLogEntries();
 
         // Ensure we have JSON serialisable elements
-        foundEntries.forEach(e->jsonArray.add(new LogDataJson(e).toJson()));
+        foundEntries.forEach(e->jsonArray.add(new AuditDataJson(e).toJson()));
         return jsonArray.build();
     }
 

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/AuditData.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/AuditData.java
@@ -8,9 +8,9 @@ import java.util.stream.Stream;
 /**
  * A class representing a log or audit entry. This class is marked abstract
  * to force extending classes to implement to X serialisation. For example
- * toJson in the LogDataJson class
+ * toJson in the AuditDataJson class
  */
-public abstract class LogData {
+public abstract class AuditData {
     private ServiceNames serviceName;
     private String logId;
     private Instant timestamp;
@@ -19,15 +19,15 @@ public abstract class LogData {
     private String userId;
 
     /**
-     * Constructs a new LogData instance which represents a log or audit message
+     * Constructs a new AuditData instance which represents a log or audit message
      * @param timestamp The time of the log message
      * @param logLevel The level associated with this log message
      * @param content The message content of this log entry
      * @param userId The user associated with this log entry
      * @param serviceName The service associated with this log entry
      */
-    protected LogData(final Instant timestamp, final LoggingLevels logLevel,
-                      final String content, final String userId, final ServiceNames serviceName) {
+    protected AuditData(final Instant timestamp, final LoggingLevels logLevel,
+                        final String content, final String userId, final ServiceNames serviceName) {
         this.logId = UUID.randomUUID().toString();
         this.timestamp = timestamp;
         this.logLevel = logLevel;
@@ -39,9 +39,9 @@ public abstract class LogData {
     /**
      * Implements a copy constructor which is invoked when switching
      * the outer serialisation methods by the extending class
-     * @param other The existing LogData to copy
+     * @param other The existing AuditData to copy
      */
-    protected LogData(LogData other){
+    protected AuditData(AuditData other){
         this.logId = other.logId;
         this.timestamp = other.timestamp;
         this.logLevel = other.logLevel;
@@ -98,7 +98,7 @@ public abstract class LogData {
     public ServiceNames getServiceName() { return serviceName; }
 
     /**
-     * Overrides and implements the equality operator for LogData objects.
+     * Overrides and implements the equality operator for AuditData objects.
      * This is marked final as deriving classes should only serialise
      * not implement operators and is agnostic of the serialising method.
      * @param obj The object to compare to
@@ -110,11 +110,11 @@ public abstract class LogData {
             return false;
         }
 
-        if (!LogData.class.isAssignableFrom(obj.getClass())){
+        if (!AuditData.class.isAssignableFrom(obj.getClass())){
             return false;
         }
 
-        final LogData other = (LogData) obj;
+        final AuditData other = (AuditData) obj;
         return this.logId.equals(other.logId) && this.timestamp.equals(other.timestamp)
                 && this.logLevel == other.logLevel && this.content.equals(other.content) &&
                 this.userId.equals(other.userId) && this.serviceName == other.serviceName;
@@ -133,13 +133,13 @@ public abstract class LogData {
 
 
     /**
-     * Returns if all the data fields within LogData are populated
+     * Returns if all the data fields within AuditData are populated
      * and not null. If any fields are null a false is returned
      * @return True if all fields are populated, else false
      */
     public final boolean isValid() {
         // GSON can return a log with all fields set to null
-        Field[] logDataFields = LogData.class.getDeclaredFields();
+        Field[] logDataFields = AuditData.class.getDeclaredFields();
 
         // We use reflection to check all fields of this class are not null
         return Stream.of(logDataFields).allMatch(it -> {

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/AuditDataJson.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/AuditDataJson.java
@@ -14,10 +14,10 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class LogDataJson extends LogData {
+public class AuditDataJson extends AuditData {
 
     /**
-     * Constructs a new LogDataJson instance which implements a
+     * Constructs a new AuditDataJson instance which implements a
      * JSON serialiser for the underlying class
      * @param timestamp The time of the log message
      * @param logLevel The level associated with this log message
@@ -25,18 +25,18 @@ public class LogDataJson extends LogData {
      * @param userId The user associated with this log entry
      * @param serviceName The micro-service associated with this log entry
      */
-    public LogDataJson(final Instant timestamp, final LoggingLevels logLevel,
-                          final String content, final String userId, final ServiceNames serviceName){
+    public AuditDataJson(final Instant timestamp, final LoggingLevels logLevel,
+                         final String content, final String userId, final ServiceNames serviceName){
         super(timestamp, logLevel, content, userId, serviceName);
     }
 
     /**
-     * Constructs a new LogDataJson from a differing serialising implementation
+     * Constructs a new AuditDataJson from a differing serialising implementation
      * to a JSON serialiser
-     * @param existingLogData An existing differing type of serialising JSON
+     * @param existingAuditData An existing differing type of serialising JSON
      */
-    public LogDataJson(LogData existingLogData){
-        super(existingLogData);
+    public AuditDataJson(AuditData existingAuditData){
+        super(existingAuditData);
     }
 
 
@@ -56,19 +56,19 @@ public class LogDataJson extends LogData {
     }
 
     /**
-     * Serialises from a single JSON object into a LogDataJson
-     * object, which implements LogData
+     * Serialises from a single JSON object into a AuditDataJson
+     * object, which implements AuditData
      * @param jsonObject The JSON representing the LogDataObject
-     * @return LogDataJson object for the log entry
+     * @return AuditDataJson object for the log entry
      * @throws JsonParseException If all fields are not present and valid
      */
-    public static LogDataJson fromJson(JsonObject jsonObject) throws JsonParseException {
+    public static AuditDataJson fromJson(JsonObject jsonObject) throws JsonParseException {
         GsonBuilder gsonBuilder = new GsonBuilder();
         // Register a custom adaptor to convert to instant from strings
         gsonBuilder.registerTypeAdapter(Instant.class, GsonTimeDeserialiser.INSTANT_DESERIALISER);
 
         Gson gson = gsonBuilder.create();
-        LogDataJson returnedObj = gson.fromJson(jsonObject.toString(), LogDataJson.class);
+        AuditDataJson returnedObj = gson.fromJson(jsonObject.toString(), AuditDataJson.class);
         returnedObj.generateLogId();
 
         if (!returnedObj.isValid()){
@@ -79,22 +79,22 @@ public class LogDataJson extends LogData {
     }
 
     /**
-     * Serialises from multiple JSON Objects into a list of LogDataJson
-     * objects, all of which implement LogData
+     * Serialises from multiple JSON Objects into a list of AuditDataJson
+     * objects, all of which implement AuditData
      * @param jsonArray The array containing JSON arrays
-     * @return List of LogData objects
-     * @throws JsonParseException If any LogData objects are invalid or there are none present
+     * @return List of AuditData objects
+     * @throws JsonParseException If any AuditData objects are invalid or there are none present
      */
-    public static List<LogDataJson> fromJson(JsonArray jsonArray) throws JsonParseException{
+    public static List<AuditDataJson> fromJson(JsonArray jsonArray) throws JsonParseException{
         GsonBuilder gsonBuilder = new GsonBuilder();
         // Register a custom adaptor to convert to instant from strings
         gsonBuilder.registerTypeAdapter(Instant.class, GsonTimeDeserialiser.INSTANT_DESERIALISER);
 
         Gson gson = gsonBuilder.create();
-        LogDataJson[] converted = gson.fromJson(jsonArray.toString(), LogDataJson[].class);
-        Stream.of(converted).forEach(LogData::generateLogId);
+        AuditDataJson[] converted = gson.fromJson(jsonArray.toString(), AuditDataJson[].class);
+        Stream.of(converted).forEach(AuditData::generateLogId);
 
-        boolean allValid = Stream.of(converted).allMatch(LogData::isValid);
+        boolean allValid = Stream.of(converted).allMatch(AuditData::isValid);
 
         if (converted.length == 0 || !allValid){
             throw new JsonParseException("Partial, invalid or empty JSON array was received");

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/AuditDataNoSerial.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/AuditDataNoSerial.java
@@ -7,26 +7,26 @@ import java.time.Instant;
  * This can be converted to any other serialisable format
  * by constructing the required format
  */
-public class LogDataNoSerial extends LogData {
+public class AuditDataNoSerial extends AuditData {
     /**
-     * Creates a new LogDataNoSerial class with the specified data
+     * Creates a new AuditDataNoSerial class with the specified data
      * @param timestamp The time of the log message
      * @param logLevel The level associated with this log message
      * @param content The message content of this log entry
      * @param userId The user associated with this log entry
      * @param serviceName The service associated with this log entry
      */
-    public LogDataNoSerial(final Instant timestamp, final LoggingLevels logLevel,
-                           final String content, final String userId, final ServiceNames serviceName){
+    public AuditDataNoSerial(final Instant timestamp, final LoggingLevels logLevel,
+                             final String content, final String userId, final ServiceNames serviceName){
         super(timestamp, logLevel, content, userId, serviceName);
     }
 
     /**
      * Converts an existing LogDataX class which can serialise into
      * a class which only holds data
-     * @param other An instance of LogData or deriving type to convert from
+     * @param other An instance of AuditData or deriving type to convert from
      */
-    public LogDataNoSerial(LogData other){
+    public AuditDataNoSerial(AuditData other){
         super(other);
     }
 }

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/DatabaseConnection.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/DatabaseConnection.java
@@ -21,22 +21,22 @@ public class DatabaseConnection implements IDatabaseConnection{
     }
 
     @Override
-    public void addLogData(LogData newLogEntry) throws IOException {
+    public void addLogData(AuditData newLogEntry) throws IOException {
 
     }
 
     @Override
-    public LogData getLogEntry(String logId) throws IOException, NoSuchElementException {
+    public AuditData getLogEntry(String logId) throws IOException, NoSuchElementException {
         return null;
     }
 
     @Override
-    public List<LogData> findLogEntry(LogData searchCriteria) throws IOException {
+    public List<AuditData> findLogEntry(AuditData searchCriteria) throws IOException {
         return null;
     }
 
     @Override
-    public List<LogData> getAllLogEntries() throws IOException {
+    public List<AuditData> getAllLogEntries() throws IOException {
         return null;
     }
 

--- a/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/IDatabaseConnection.java
+++ b/src/main/java/uk/ac/aber/dcs/aberfitness/glados/db/IDatabaseConnection.java
@@ -30,7 +30,7 @@ public interface IDatabaseConnection {
      * @param newLogEntry The log entry to add
      * @throws IOException If the entry could not be added
      */
-    void addLogData(LogData newLogEntry) throws IOException;
+    void addLogData(AuditData newLogEntry) throws IOException;
 
     /**
      * Returns the specified log entry from the db if it exists.
@@ -41,7 +41,7 @@ public interface IDatabaseConnection {
      * @throws NoSuchElementException If the requested ID does not exist
      * @throws IOException If the request could not be completed
      */
-    LogData getLogEntry(String logId) throws IOException, NoSuchElementException;
+    AuditData getLogEntry(String logId) throws IOException, NoSuchElementException;
 
     /**
      * Returns all matching log entries based on the search criteria passed
@@ -51,7 +51,7 @@ public interface IDatabaseConnection {
      * @return All matching entries in a list. An empty list if none are found
      * @throws IOException If the request could not be completed
      */
-    List<LogData> findLogEntry(LogData searchCriteria) throws IOException;
+    List<AuditData> findLogEntry(AuditData searchCriteria) throws IOException;
 
     /**
      * Returns all log entries within the DB as a list.
@@ -60,7 +60,7 @@ public interface IDatabaseConnection {
      * @throws IOException If the request could not be completed
      */
     // TODO add limits
-    List<LogData> getAllLogEntries() throws IOException;
+    List<AuditData> getAllLogEntries() throws IOException;
 
     /**
      * Attempts to remove the given logId. The entry is allowed to not exist too.

--- a/src/test/java/IntegrationTest/AuditApiTest.java
+++ b/src/test/java/IntegrationTest/AuditApiTest.java
@@ -1,0 +1,4 @@
+package IntegrationTest;
+
+public class AuditApiTest {
+}

--- a/src/test/java/UnitTest/AuditApiTest.java
+++ b/src/test/java/UnitTest/AuditApiTest.java
@@ -1,11 +1,13 @@
-import helpers.LogDataHelpers;
+package UnitTest;
+
+import helpers.AuditDataHelpers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import uk.ac.aber.dcs.aberfitness.glados.api.LogApi;
+import uk.ac.aber.dcs.aberfitness.glados.api.AuditApi;
 import uk.ac.aber.dcs.aberfitness.glados.db.*;
 
 import javax.json.JsonArray;
@@ -16,45 +18,45 @@ import java.util.List;
 
 import static org.mockito.Mockito.when;
 
-public class LogApiTest {
+public class AuditApiTest {
     @Mock
     private DatabaseConnection dbMock;
 
     // Ensure we replace the injected concrete type with the mock db connection
     @InjectMocks
-    private LogApi apiInstance;
+    private AuditApi apiInstance;
 
     @Before
     public void setUp() {
-        apiInstance = new LogApi();
+        apiInstance = new AuditApi();
         MockitoAnnotations.initMocks(this);
     }
 
     /**
-     * Returns a sample LogData entry for unit testing
-     * @return A sample LogData object
+     * Returns a sample AuditData entry for unit testing
+     * @return A sample AuditData object
      */
-    private LogData createExampleLogData() {
-        return new LogDataNoSerial(Instant.now(), LoggingLevels.DEBUG, "TestContent",
+    private AuditData createExampleLogData() {
+        return new AuditDataNoSerial(Instant.now(), LoggingLevels.DEBUG, "TestContent",
                 "abc123", ServiceNames.GLADOS);
     }
 
     @Test
     public void findAllCallReturnsAll() throws IOException {
-        LogData dummyLogOne = createExampleLogData();
-        LogData dummyLogTwo = createExampleLogData();
+        AuditData dummyLogOne = createExampleLogData();
+        AuditData dummyLogTwo = createExampleLogData();
 
-        List<LogData> mockedData = Arrays.asList(dummyLogOne, dummyLogTwo);
+        List<AuditData> mockedData = Arrays.asList(dummyLogOne, dummyLogTwo);
         when(dbMock.getAllLogEntries()).thenReturn(mockedData);
 
         // This should return JSON
         JsonArray returnedJson = apiInstance.getAllEntries();
-        List<LogDataJson> returnedEntries = LogDataJson.fromJson(returnedJson);
+        List<AuditDataJson> returnedEntries = AuditDataJson.fromJson(returnedJson);
 
         Assert.assertEquals(returnedEntries.size(), mockedData.size());
 
         for (int i = 0; i < returnedEntries.size(); i++) {
-            LogDataHelpers.isAlmostEqual(returnedEntries.get(i), mockedData.get(i));
+            AuditDataHelpers.isAlmostEqual(returnedEntries.get(i), mockedData.get(i));
         }
     }
 

--- a/src/test/java/UnitTest/AuditDataJsonTest.java
+++ b/src/test/java/UnitTest/AuditDataJsonTest.java
@@ -1,5 +1,7 @@
+package UnitTest;
+
 import com.google.gson.JsonParseException;
-import helpers.LogDataHelpers;
+import helpers.AuditDataHelpers;
 import org.junit.Assert;
 import org.junit.Test;
 import uk.ac.aber.dcs.aberfitness.glados.db.*;
@@ -12,26 +14,26 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class LogDataJsonTest {
-    private JsonObject createFakeJson(LogData logData) {
+public class AuditDataJsonTest {
+    private JsonObject createFakeJson(AuditData auditData) {
 
         JsonObjectBuilder newJsonObject = Json.createObjectBuilder();
 
 
-        newJsonObject.add("timestamp", logData.getTimestamp().toString())
-                .add("userId", logData.getUserId())
-                .add("logLevel", logData.getLogLevel().toString())
-                .add("content", logData.getContent())
-                .add("serviceName", logData.getServiceName().toString());
+        newJsonObject.add("timestamp", auditData.getTimestamp().toString())
+                .add("userId", auditData.getUserId())
+                .add("logLevel", auditData.getLogLevel().toString())
+                .add("content", auditData.getContent())
+                .add("serviceName", auditData.getServiceName().toString());
         return newJsonObject.build();
     }
 
     @Test
     public void ConvertsFromOtherSerialisingTypeCorrectly() {
-        LogDataNoSerial noSerial = new LogDataNoSerial(Instant.now(), LoggingLevels.DEBUG,
+        AuditDataNoSerial noSerial = new AuditDataNoSerial(Instant.now(), LoggingLevels.DEBUG,
                 "test", "abc123", ServiceNames.GLADOS);
 
-        LogDataJson convertedInstance = new LogDataJson(noSerial);
+        AuditDataJson convertedInstance = new AuditDataJson(noSerial);
         Assert.assertNotNull(convertedInstance);
 
         // These are equiv if converted correctly
@@ -46,7 +48,7 @@ public class LogDataJsonTest {
         String userId = "test123";
         ServiceNames serviceName = ServiceNames.GLADOS;
 
-        final LogDataJson testInstance = new LogDataJson(now, logLevel, sampleMsg, userId, serviceName);
+        final AuditDataJson testInstance = new AuditDataJson(now, logLevel, sampleMsg, userId, serviceName);
         JsonObject returnedJson = testInstance.toJson();
 
         Assert.assertEquals(returnedJson.getString("timestamp"), now.toString());
@@ -65,12 +67,12 @@ public class LogDataJsonTest {
         String fakeId = "12345";
         ServiceNames serviceName = ServiceNames.GLADOS;
 
-        LogData referenceInstance = new LogDataNoSerial(now, logLevel, sampleMsg, userId, serviceName);
+        AuditData referenceInstance = new AuditDataNoSerial(now, logLevel, sampleMsg, userId, serviceName);
 
         JsonObject testJson = createFakeJson(referenceInstance);
 
-        LogDataJson returnedClass = LogDataJson.fromJson(testJson);
-        LogDataHelpers.isAlmostEqual(referenceInstance, returnedClass);
+        AuditDataJson returnedClass = AuditDataJson.fromJson(testJson);
+        AuditDataHelpers.isAlmostEqual(referenceInstance, returnedClass);
     }
 
     @Test
@@ -81,9 +83,9 @@ public class LogDataJsonTest {
         String userId = "test123";
         ServiceNames serviceName = ServiceNames.GLADOS;
 
-        final LogDataJson testObjOne = new LogDataJson(now, logLevel, sampleMsg, "101", serviceName);
-        final LogDataJson testObjTwo = new LogDataJson(now, logLevel, sampleMsg, "102", serviceName);
-        final LogDataJson testObjThree = new LogDataJson(now, logLevel, sampleMsg, "103", serviceName);
+        final AuditDataJson testObjOne = new AuditDataJson(now, logLevel, sampleMsg, "101", serviceName);
+        final AuditDataJson testObjTwo = new AuditDataJson(now, logLevel, sampleMsg, "102", serviceName);
+        final AuditDataJson testObjThree = new AuditDataJson(now, logLevel, sampleMsg, "103", serviceName);
 
         JsonObject testJson = createFakeJson(testObjOne);
         JsonObject testJson2 = createFakeJson(testObjTwo);
@@ -94,12 +96,12 @@ public class LogDataJsonTest {
         jsonArrayBuilder.add(testJson).add(testJson2).add(testJson3);
         JsonArray returnedArray = jsonArrayBuilder.build();
 
-        List<LogDataJson> processedArray = LogDataJson.fromJson(returnedArray);
+        List<AuditDataJson> processedArray = AuditDataJson.fromJson(returnedArray);
 
         Assert.assertEquals(processedArray.size(), 3);
-        LogDataHelpers.isAlmostEqual(testObjOne, processedArray.get(0));
-        LogDataHelpers.isAlmostEqual(testObjTwo, processedArray.get(1));
-        LogDataHelpers.isAlmostEqual(testObjThree, processedArray.get(2));
+        AuditDataHelpers.isAlmostEqual(testObjOne, processedArray.get(0));
+        AuditDataHelpers.isAlmostEqual(testObjTwo, processedArray.get(1));
+        AuditDataHelpers.isAlmostEqual(testObjThree, processedArray.get(2));
     }
 
     @Test
@@ -110,13 +112,13 @@ public class LogDataJsonTest {
         String userId = "test123";
         ServiceNames serviceName = ServiceNames.GLADOS;
 
-        final LogDataJson testInstance = new LogDataJson(now, logLevel, sampleMsg, userId, serviceName);
+        final AuditDataJson testInstance = new AuditDataJson(now, logLevel, sampleMsg, userId, serviceName);
 
         JsonObject returnedJson = testInstance.toJson();
-        LogDataJson returnedObject = LogDataJson.fromJson(returnedJson);
+        AuditDataJson returnedObject = AuditDataJson.fromJson(returnedJson);
 
         Assert.assertTrue(returnedObject.isValid());
-        LogDataHelpers.isAlmostEqual(testInstance, returnedObject);
+        AuditDataHelpers.isAlmostEqual(testInstance, returnedObject);
     }
 
 
@@ -126,10 +128,10 @@ public class LogDataJsonTest {
         JsonArray blankArray = Json.createArrayBuilder().build();
 
         assertThrows(JsonParseException.class, () -> {
-            LogDataJson.fromJson(blankObj);
+            AuditDataJson.fromJson(blankObj);
         });
         assertThrows(JsonParseException.class, () -> {
-            LogDataJson.fromJson(blankArray);
+            AuditDataJson.fromJson(blankArray);
         });
 
     }
@@ -143,13 +145,13 @@ public class LogDataJsonTest {
         JsonObject partialJson = partialObj.build();
 
         assertThrows(JsonParseException.class, () -> {
-            LogDataJson.fromJson(partialJson);
+            AuditDataJson.fromJson(partialJson);
         });
     }
 
     @Test
     public void JsonParseExceptionIsThrownForBadFieldName() {
-        final LogDataJson testInstance = new LogDataJson(Instant.now(), LoggingLevels.DEBUG,
+        final AuditDataJson testInstance = new AuditDataJson(Instant.now(), LoggingLevels.DEBUG,
                 "test", "abc123", ServiceNames.GLADOS);
 
         JsonObject fakeJson = createFakeJson(testInstance);
@@ -163,7 +165,7 @@ public class LogDataJsonTest {
         JsonObject replacedJson = parser.getObject();
 
         assertThrows(JsonParseException.class, () -> {
-            LogDataJson.fromJson(replacedJson);
+            AuditDataJson.fromJson(replacedJson);
         });
     }
 }

--- a/src/test/java/UnitTest/AuditDataTest.java
+++ b/src/test/java/UnitTest/AuditDataTest.java
@@ -1,15 +1,14 @@
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+package UnitTest;
+
 import org.junit.Assert;
 import org.junit.Test;
-import uk.ac.aber.dcs.aberfitness.glados.db.LogDataNoSerial;
-import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
-import uk.ac.aber.dcs.aberfitness.glados.db.LoggingLevels;
-import uk.ac.aber.dcs.aberfitness.glados.db.ServiceNames;
+import uk.ac.aber.dcs.aberfitness.glados.db.*;
+import uk.ac.aber.dcs.aberfitness.glados.db.AuditDataNoSerial;
+import uk.ac.aber.dcs.aberfitness.glados.db.AuditData;
 
 import java.time.Instant;
 
-public class LogDataTest {
+public class AuditDataTest {
 
     @Test
     public void LogDataGetters() {
@@ -19,7 +18,7 @@ public class LogDataTest {
         String userId = "test123";
         ServiceNames testName = ServiceNames.GLADOS;
 
-        final LogData testInstance = new LogDataNoSerial(now, logLevel, sampleMsg, userId, testName);
+        final AuditData testInstance = new AuditDataNoSerial(now, logLevel, sampleMsg, userId, testName);
 
         Assert.assertEquals(testInstance.getTimestamp(), now);
         Assert.assertEquals(testInstance.getContent(), sampleMsg);
@@ -33,9 +32,9 @@ public class LogDataTest {
         Instant now = Instant.now();
 
         // Regardless of other fields the log id should always be unique
-        final LogData testInstanceOne = new LogDataNoSerial(now, LoggingLevels.DEBUG,
+        final AuditData testInstanceOne = new AuditDataNoSerial(now, LoggingLevels.DEBUG,
                 "test", "id1", ServiceNames.GLADOS);
-        final LogData testInstanceTwo = new LogDataNoSerial(now, LoggingLevels.DEBUG,
+        final AuditData testInstanceTwo = new AuditDataNoSerial(now, LoggingLevels.DEBUG,
                 "test", "id1", ServiceNames.GLADOS);
 
         Assert.assertNotEquals(testInstanceOne.getLogId(), testInstanceTwo.getLogId());
@@ -43,10 +42,10 @@ public class LogDataTest {
 
     @Test
     public void LogDataCopyConstructor(){
-        final LogData testInstanceOne = new LogDataNoSerial(Instant.now(), LoggingLevels.DEBUG,
+        final AuditData testInstanceOne = new AuditDataNoSerial(Instant.now(), LoggingLevels.DEBUG,
                 "test", "id1", ServiceNames.GLADOS);
 
-        final LogData testInstanceTwo = new LogDataNoSerial(testInstanceOne);
+        final AuditData testInstanceTwo = new AuditDataNoSerial(testInstanceOne);
 
         Assert.assertEquals(testInstanceOne, testInstanceTwo);
     }

--- a/src/test/java/helpers/AuditDataHelpers.java
+++ b/src/test/java/helpers/AuditDataHelpers.java
@@ -1,13 +1,13 @@
 package helpers;
 
 import org.junit.Assert;
-import uk.ac.aber.dcs.aberfitness.glados.db.LogData;
+import uk.ac.aber.dcs.aberfitness.glados.db.AuditData;
 
-public class LogDataHelpers {
+public class AuditDataHelpers {
     /**
      * Compares all fields except UUID which cannot be set through JSON
      */
-    static public void isAlmostEqual(LogData one, LogData two){
+    static public void isAlmostEqual(AuditData one, AuditData two){
         Assert.assertEquals(one.getUserId(), two.getUserId());
         Assert.assertEquals(one.getLogLevel(), two.getLogLevel());
         Assert.assertEquals(one.getContent(), two.getContent());


### PR DESCRIPTION
Renames all instances from Log* to Audit* to reflect us migrating to syslog for logging

Additionally I've added Arquillian deps in preparation for integration testing - as I want to see how they play with Travis before committing to writing tests