### PR TITLE
Add admin page for audit data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,11 @@ RUN apk add maven openjdk8
 RUN mkdir /app
 WORKDIR /app
 RUN mkdir src
-COPY src src
+
 COPY pom.xml .
+RUN mvn dependency:go-offline
+
+COPY src src
 
 # Maven Stages
 RUN ${RUN_TESTS} && echo "Running tests...." && mvn test -B

--- a/glados.iml
+++ b/glados.iml
@@ -93,8 +93,7 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.sun.mail:javax.mail:1.5.0" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.activation:activation:1.1" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:javax.servlet-api:3.1.0" level="project" />
-    <orderEntry type="library" name="Maven: com.sun.faces:jsf-api:2.2.18" level="project" />
-    <orderEntry type="library" name="Maven: com.sun.faces:jsf-impl:2.2.18" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.faces:javax.faces-api:2.3" level="project" />
     <orderEntry type="library" name="Maven: org.hibernate:hibernate-core:5.3.7.Final" level="project" />
     <orderEntry type="library" name="Maven: org.jboss.logging:jboss-logging:3.3.2.Final" level="project" />
     <orderEntry type="library" name="Maven: javax.persistence:javax.persistence-api:2.2" level="project" />

--- a/glados.iml
+++ b/glados.iml
@@ -111,6 +111,13 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.glassfish.hk2.external:javax.inject:2.5.0-b42" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.glassfish.hk2:osgi-resource-locator:1.0.1" level="project" />
     <orderEntry type="library" name="Maven: org.primefaces:primefaces:6.2" level="project" />
+    <orderEntry type="library" name="Maven: com.github.scribejava:scribejava-apis:6.1.0" level="project" />
+    <orderEntry type="library" name="Maven: com.github.scribejava:scribejava-core:6.1.0" level="project" />
+    <orderEntry type="library" name="Maven: com.nimbusds:nimbus-jose-jwt:6.4.2" level="project" />
+    <orderEntry type="library" name="Maven: com.github.stephenc.jcip:jcip-annotations:1.0-1" level="project" />
+    <orderEntry type="library" name="Maven: net.minidev:json-smart:2.3" level="project" />
+    <orderEntry type="library" name="Maven: net.minidev:accessors-smart:1.2" level="project" />
+    <orderEntry type="library" name="Maven: org.ow2.asm:asm:5.0.4" level="project" />
     <orderEntry type="library" name="Maven: javax.json:javax.json-api:1.1" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish:javax.json:1.1" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.5" level="project" />

--- a/glados.iml
+++ b/glados.iml
@@ -110,8 +110,7 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.glassfish.jersey.core:jersey-common:2.26" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.glassfish.hk2.external:javax.inject:2.5.0-b42" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.glassfish.hk2:osgi-resource-locator:1.0.1" level="project" />
-    <orderEntry type="library" name="Maven: com.github.scribejava:scribejava-apis:6.0.0" level="project" />
-    <orderEntry type="library" name="Maven: com.github.scribejava:scribejava-core:6.0.0" level="project" />
+    <orderEntry type="library" name="Maven: org.primefaces:primefaces:6.2" level="project" />
     <orderEntry type="library" name="Maven: javax.json:javax.json-api:1.1" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish:javax.json:1.1" level="project" />
     <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.5" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -68,12 +68,14 @@
         </dependency>
 
 
-        <!-- Scribe -->
+        <!-- Prime Faces -->
         <dependency>
-            <groupId>com.github.scribejava</groupId>
-            <artifactId>scribejava-apis</artifactId>
-            <version>6.0.0</version>
+            <groupId>org.primefaces</groupId>
+            <artifactId>primefaces</artifactId>
+            <version>6.2</version>
         </dependency>
+
+
 
         <!-- JSON Parsing -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
             <scope>test</scope>
         </dependency>
 
-
         <!-- Prime Faces -->
         <dependency>
             <groupId>org.primefaces</groupId>
@@ -75,7 +74,19 @@
             <version>6.2</version>
         </dependency>
 
+        <!-- Scribe -->
+        <dependency>
+            <groupId>com.github.scribejava</groupId>
+            <artifactId>scribejava-apis</artifactId>
+            <version>6.1.0</version>
+        </dependency>
 
+        <!-- JOSE -->
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>6.4.2</version>
+        </dependency>
 
         <!-- JSON Parsing -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -38,15 +38,13 @@
             <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
+
+        <!-- JSF -->
         <dependency>
-            <groupId>com.sun.faces</groupId>
-            <artifactId>jsf-api</artifactId>
-            <version>2.2.18</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.faces</groupId>
-            <artifactId>jsf-impl</artifactId>
-            <version>2.2.18</version>
+            <groupId>javax.faces</groupId>
+            <artifactId>javax.faces-api</artifactId>
+            <version>2.3</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- ORM -->

--- a/src/main/java/beans/HelloBacking.java
+++ b/src/main/java/beans/HelloBacking.java
@@ -1,0 +1,12 @@
+package beans;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Named;
+
+@Named
+@RequestScoped
+public class HelloBacking {
+    public String getHello(){
+        return "HEllo world";
+    }
+}

--- a/src/main/java/beans/OAuthBean.java
+++ b/src/main/java/beans/OAuthBean.java
@@ -1,0 +1,34 @@
+package beans;
+
+import com.github.scribejava.core.builder.ServiceBuilder;
+import com.github.scribejava.core.oauth.OAuth20Service;
+import configuration.EnvironmentVariables;
+import oauth.GatekeeperApi;
+
+import javax.ejb.Singleton;
+
+@Singleton
+public class OAuthBean {
+
+    private OAuth20Service aberfitnessService;
+
+
+    //"openid profile offline_access"
+    public void initGatekeeperService(String callback, String state, String scope) {
+        if (aberfitnessService != null && aberfitnessService.getCallback().equals(callback) && aberfitnessService.getScope().equals(scope))
+            return;
+
+        if (EnvironmentVariables.isAberfitnessDataPresent()) {
+            aberfitnessService = new ServiceBuilder(EnvironmentVariables.getAberfitnessClientId())
+                    .apiSecret(EnvironmentVariables.getAberfitnessClientSecret())
+                    .scope(scope)
+                    .callback(callback)
+                    .state(state)
+                    .build(GatekeeperApi.instance());
+        }
+    }
+
+    public OAuth20Service getAberfitnessService() {
+        return aberfitnessService;
+    }
+}

--- a/src/main/java/beans/UserDataLookupBacking.java
+++ b/src/main/java/beans/UserDataLookupBacking.java
@@ -1,0 +1,55 @@
+package beans;
+
+import entities.AuditData;
+import persistence.DatabaseConnection;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+import javax.inject.Named;
+import java.util.Date;
+import java.util.List;
+
+@Stateless
+@Named
+public class UserDataLookupBacking {
+
+    private Date startingTime;
+    private Date endingTime;
+
+    private List<AuditData> results;
+    private boolean hasRequestedResults = false;
+
+    @EJB
+    private DatabaseConnection db;
+
+    // Invoked methods
+    public void lookupResults(){
+        // TODO make this specific for the current user
+        hasRequestedResults = true;
+        results = db.getAllLogEntries();
+    }
+
+    public boolean getHasRequestedResults(){
+        return hasRequestedResults;
+    }
+
+    public List<AuditData> getResults(){
+        return results;
+    }
+
+    public Date getStartingTime() {
+        return startingTime;
+    }
+
+    public void setStartingTime(Date startingTime) {
+        this.startingTime = startingTime;
+    }
+
+    public Date getEndingTime() {
+        return endingTime;
+    }
+
+    public void setEndingTime(Date endingTime) {
+        this.endingTime = endingTime;
+    }
+}

--- a/src/main/java/beans/UserDataLookupBacking.java
+++ b/src/main/java/beans/UserDataLookupBacking.java
@@ -10,7 +10,6 @@ import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.inject.Named;
 import java.io.IOException;
-import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 

--- a/src/main/java/beans/UserDataLookupBacking.java
+++ b/src/main/java/beans/UserDataLookupBacking.java
@@ -1,17 +1,19 @@
 package beans;
 
+import beans.helpers.LoginSession;
 import entities.AuditData;
 import persistence.DatabaseConnection;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateless;
 import javax.inject.Named;
+import java.io.IOException;
 import java.util.Date;
 import java.util.List;
 
 @Stateless
 @Named
-public class UserDataLookupBacking {
+public class UserDataLookupBacking extends LoginSession {
 
     private Date startingTime;
     private Date endingTime;
@@ -19,15 +21,20 @@ public class UserDataLookupBacking {
     private List<AuditData> results;
     private boolean hasRequestedResults = false;
 
-    // TODO
-    private String userId = "TODO";
+    private String userToLookup;
     private boolean currentUserIsAdmin = false;
 
     @EJB
     private DatabaseConnection db;
 
+
     // Invoked methods
-    public void lookupResults(){
+    public void onLoad() throws IOException {
+        checkUserLogin();
+        userToLookup = super.getUserId();
+    }
+
+    public void lookupResults() {
         // TODO make this specific for the current user
         hasRequestedResults = true;
         results = db.getAllLogEntries();
@@ -35,28 +42,28 @@ public class UserDataLookupBacking {
 
     // ---- Getters only -----
 
-    public boolean getHasRequestedResults(){
+    public boolean getHasRequestedResults() {
         return hasRequestedResults;
     }
 
-    public boolean getCurrentUserIsAdmin(){
+    public boolean getCurrentUserIsAdmin() {
         return currentUserIsAdmin;
     }
 
-    public List<AuditData> getResults(){
+    public List<AuditData> getResults() {
         return results;
     }
 
     // ----- Setters and Getters ------
 
-    public String getUserId() {
-        return userId;
+    public String getUserToLookup() {
+        return userToLookup;
     }
 
-    public void setUserId(String userId) {
-        if (currentUserIsAdmin){
+    public void setUserToLookup(String userToLookup) {
+        if (currentUserIsAdmin) {
             // Only Admins can lookup other users
-            this.userId = userId;
+            this.userToLookup = userToLookup;
         }
     }
 

--- a/src/main/java/beans/UserDataLookupBacking.java
+++ b/src/main/java/beans/UserDataLookupBacking.java
@@ -19,6 +19,10 @@ public class UserDataLookupBacking {
     private List<AuditData> results;
     private boolean hasRequestedResults = false;
 
+    // TODO
+    private String userId = "TODO";
+    private boolean currentUserIsAdmin = false;
+
     @EJB
     private DatabaseConnection db;
 
@@ -29,12 +33,31 @@ public class UserDataLookupBacking {
         results = db.getAllLogEntries();
     }
 
+    // ---- Getters only -----
+
     public boolean getHasRequestedResults(){
         return hasRequestedResults;
     }
 
+    public boolean getCurrentUserIsAdmin(){
+        return currentUserIsAdmin;
+    }
+
     public List<AuditData> getResults(){
         return results;
+    }
+
+    // ----- Setters and Getters ------
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        if (currentUserIsAdmin){
+            // Only Admins can lookup other users
+            this.userId = userId;
+        }
     }
 
     public Date getStartingTime() {

--- a/src/main/java/beans/helpers/LoginSession.java
+++ b/src/main/java/beans/helpers/LoginSession.java
@@ -1,0 +1,62 @@
+package beans.helpers;
+
+import oauth.GatekeeperLogin;
+
+import javax.ejb.EJB;
+import javax.faces.context.FacesContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+
+public class LoginSession {
+
+    @EJB
+    private GatekeeperLogin loginBean;
+
+    private static final String userParam = "userId";
+
+    private String userId;
+
+    public LoginSession() {
+    }
+
+    public void checkUserLogin()
+            throws IOException {
+        HttpServletRequest request = (HttpServletRequest) FacesContext.getCurrentInstance().getExternalContext().getRequest();
+        HttpServletResponse response = (HttpServletResponse) FacesContext.getCurrentInstance().getExternalContext().getResponse();
+
+        Map<String, String[]> paramMap = request.getParameterMap();
+        String authorization = request.getHeader("Authorization");
+
+        loginBean.getGatekeeperGetAccessToken(request);
+
+        if (authorization != null && authorization.startsWith("Bearer")) {
+            String[] authHead = authorization.split(" ", 2);
+
+            if (authHead[1] == null) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "No Access Token Parameter!");
+                return;
+            }
+
+            if (!paramMap.containsKey(userParam)) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "No User ID Parameter!");
+                return;
+            }
+
+            if (!loginBean.validateAccessToken(authHead[1])) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid Access Token!");
+                return;
+            }
+            // Logged in
+            userId = paramMap.get(userParam)[0];
+
+        } else {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Authorization Header Not Set or Not Bearer");
+        }
+    }
+
+    protected String getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/configuration/AuthStorage.java
+++ b/src/main/java/configuration/AuthStorage.java
@@ -1,0 +1,29 @@
+package configuration;
+
+import oauth.gatekeeper.GatekeeperOAuth2AccessToken;
+
+/**
+ * Static class for holding the Application's AccessToken
+ * @author James H Britton
+ */
+public final class AuthStorage {
+
+    private static GatekeeperOAuth2AccessToken applicationToken;
+
+    /**
+     * Function for checking if the access token has expired or not.
+     * @return true still valid, false not valid
+     */
+    public static boolean isAppTokenValid() {
+        //TODO implement
+        return false;
+    }
+
+    public static GatekeeperOAuth2AccessToken getApplicationToken() {
+        return applicationToken;
+    }
+
+    public static void setApplicationToken(GatekeeperOAuth2AccessToken applicationToken) {
+        AuthStorage.applicationToken = applicationToken;
+    }
+}

--- a/src/main/java/configuration/EnvironmentVariables.java
+++ b/src/main/java/configuration/EnvironmentVariables.java
@@ -1,0 +1,54 @@
+package configuration;
+
+public final class EnvironmentVariables {
+    private static final String systemBaseUrl = System.getenv("SYS_BASE_URL");
+
+    //Gatekeeper URL Defs
+    private static final String gatekeeperUrl = systemBaseUrl + System.getenv("GATEKEEPER_URL");
+    private static final String gatekeeperAuthoriseUrl = gatekeeperUrl + System.getenv("GK_AUTH_URL");
+    private static final String gatekeeperTokenUrl = gatekeeperUrl + System.getenv("GK_TOKEN_URL");
+    private static final String gatekeeperRevokeUrl = gatekeeperUrl + System.getenv("GK_REVOKE_URL");
+    private static final String gatekeeperJWKUrl = gatekeeperUrl + System.getenv("GK_JWK_URL");
+    private static final String gatekeeperIntrospectUrl = gatekeeperUrl + System.getenv("GK_INTROSPECT_URL");
+
+    //Aberfitness Info
+    private static final String aberfitnessClientId = System.getenv("ABERFITNESS_CLI_ID");
+    private static final String aberfitnessClientSecret = System.getenv("ABERFITNESS_CLI_SECRET");
+
+    public static String getAberfitnessClientId() {
+        return aberfitnessClientId;
+    }
+
+    public static String getAberfitnessClientSecret() {
+        return aberfitnessClientSecret;
+    }
+
+    public static String getGatekeeperUrl() {
+        return gatekeeperUrl;
+    }
+
+    public static String getGatekeeperAuthoriseUrl() {
+        return gatekeeperAuthoriseUrl;
+    }
+
+    public static String getGatekeeperTokenUrl() {
+        return gatekeeperTokenUrl;
+    }
+
+    public static String getGatekeeperRevokeUrl() {
+        return gatekeeperRevokeUrl;
+    }
+
+    public static String getGatekeeperJWKUrl() {
+        return gatekeeperJWKUrl;
+    }
+
+    public static String getGatekeeperIntrospectUrl() {
+        return gatekeeperIntrospectUrl;
+    }
+
+    public static boolean isAberfitnessDataPresent() {
+        return aberfitnessClientId != null && aberfitnessClientSecret != null;
+    }
+
+}

--- a/src/main/java/configuration/FacesConfiguration.java
+++ b/src/main/java/configuration/FacesConfiguration.java
@@ -1,0 +1,12 @@
+package configuration;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.faces.annotation.FacesConfig;
+
+/**
+ * Activates Java Facelets 2.3
+ */
+@FacesConfig(version = FacesConfig.Version.JSF_2_3)
+@ApplicationScoped
+public class FacesConfiguration {
+}

--- a/src/main/java/configuration/JAXRSConfiguration.java
+++ b/src/main/java/configuration/JAXRSConfiguration.java
@@ -1,4 +1,4 @@
-package rest;
+package configuration;
 
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;

--- a/src/main/java/oauth/GatekeeperApi.java
+++ b/src/main/java/oauth/GatekeeperApi.java
@@ -1,0 +1,42 @@
+package oauth;
+
+import com.github.scribejava.core.builder.api.DefaultApi20;
+import configuration.EnvironmentVariables;
+import oauth.gatekeeper.GatekeeperJsonTokenExtractor;
+
+/**
+ * Implements an concrete API for accessing Gatekeeper
+ */
+public class GatekeeperApi extends DefaultApi20 {
+
+        public GatekeeperApi() {}
+
+        @Override
+        public GatekeeperJsonTokenExtractor getAccessTokenExtractor() {
+            return GatekeeperJsonTokenExtractor.instance();
+        }
+
+        private static class InstanceHolder {
+            private static final GatekeeperApi INSTANCE = new GatekeeperApi();
+        }
+
+        public static GatekeeperApi instance() {
+            return InstanceHolder.INSTANCE;
+        }
+
+        @Override
+        public String getAccessTokenEndpoint() {
+            return EnvironmentVariables.getGatekeeperTokenUrl();
+        }
+
+        @Override
+        public String getRevokeTokenEndpoint() {
+            return EnvironmentVariables.getGatekeeperRevokeUrl();
+        }
+
+        @Override
+        protected String getAuthorizationBaseUrl() {
+            return EnvironmentVariables.getGatekeeperAuthoriseUrl();
+        }
+
+}

--- a/src/main/java/oauth/GatekeeperLogin.java
+++ b/src/main/java/oauth/GatekeeperLogin.java
@@ -1,0 +1,69 @@
+package oauth;
+
+
+import beans.OAuthBean;
+import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.nimbusds.jwt.JWTClaimsSet;
+import oauth.gatekeeper.GatekeeperJsonTokenExtractor;
+import oauth.gatekeeper.GatekeeperOAuth2AccessToken;
+
+import javax.ejb.EJB;
+import javax.ejb.Stateful;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Serializable;
+
+@Stateful
+public class GatekeeperLogin implements Serializable {
+
+    @EJB
+    OAuthBean oAuthBean;
+
+    private GatekeeperOAuth2AccessToken userAccessToken;
+
+    public GatekeeperLogin() {
+        //
+    }
+
+    public void redirectToGatekeeper(HttpServletResponse response, String callback, String state) throws IOException {
+        oAuthBean.initGatekeeperService(callback, state, "openid profile offline_access");
+        String url = oAuthBean.getAberfitnessService().getAuthorizationUrl();
+        response.sendRedirect(url);
+    }
+
+    public void getGatekeeperGetAccessToken(HttpServletRequest request) {
+        userAccessToken = null;
+        String str = request.getParameter("code");
+        if (str != null) {
+            try {
+                OAuth2AccessToken inAccessToken = oAuthBean.getAberfitnessService().getAccessToken(str);
+                if (!(inAccessToken instanceof GatekeeperOAuth2AccessToken))
+                    return;
+
+                userAccessToken = (GatekeeperOAuth2AccessToken) inAccessToken;
+                System.out.println("USER ID IN GATE AT: " + userAccessToken.getUserId());
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public boolean validateAccessToken(String accessToken) {
+        try {
+            JWTClaimsSet claimsSet = GatekeeperJsonTokenExtractor.instance().getJWTClaimSet(accessToken);
+            System.out.println("Token Issued By: " + claimsSet.getIssuer());
+
+            return true;
+        } catch (Exception e) {
+            System.err.println("[GatekeeperLogin.validateAccessToken] Message:" + e.getMessage() + " Cause: " + e.getCause());
+            return false;
+        }
+    }
+
+    public String getUser_id() {
+        if (userAccessToken != null)
+            return userAccessToken.getUserId();
+        return null;
+    }
+}

--- a/src/main/java/oauth/GatekeeperLogin.java
+++ b/src/main/java/oauth/GatekeeperLogin.java
@@ -3,9 +3,18 @@ package oauth;
 
 import beans.OAuthBean;
 import com.github.scribejava.core.model.OAuth2AccessToken;
+import com.github.scribejava.core.model.OAuthRequest;
+import com.github.scribejava.core.model.Response;
+import com.github.scribejava.core.model.Verb;
+import com.github.scribejava.core.oauth.OAuth20Service;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.nimbusds.jwt.JWTClaimsSet;
+import configuration.EnvironmentVariables;
+import oauth.gatekeeper.GatekeeperInfo;
 import oauth.gatekeeper.GatekeeperJsonTokenExtractor;
 import oauth.gatekeeper.GatekeeperOAuth2AccessToken;
+import oauth.gatekeeper.UserType;
 
 import javax.ejb.EJB;
 import javax.ejb.Stateful;
@@ -13,6 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.concurrent.ExecutionException;
 
 @Stateful
 public class GatekeeperLogin implements Serializable {
@@ -23,7 +33,6 @@ public class GatekeeperLogin implements Serializable {
     private GatekeeperOAuth2AccessToken userAccessToken;
 
     public GatekeeperLogin() {
-        //
     }
 
     public void redirectToGatekeeper(HttpServletResponse response, String callback, String state) throws IOException {
@@ -32,22 +41,26 @@ public class GatekeeperLogin implements Serializable {
         response.sendRedirect(url);
     }
 
-    public void getGatekeeperGetAccessToken(HttpServletRequest request) {
-        userAccessToken = null;
+    public String getGatekeeperGetAccessToken(HttpServletRequest request) {
         String str = request.getParameter("code");
-        if (str != null) {
-            try {
-                OAuth2AccessToken inAccessToken = oAuthBean.getAberfitnessService().getAccessToken(str);
-                if (!(inAccessToken instanceof GatekeeperOAuth2AccessToken))
-                    return;
-
-                userAccessToken = (GatekeeperOAuth2AccessToken) inAccessToken;
-                System.out.println("USER ID IN GATE AT: " + userAccessToken.getUserId());
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+        if (str == null) {
+            System.out.println("Code was null");
+            return null;
         }
+
+        try {
+            OAuth2AccessToken inAccessToken = oAuthBean.getAberfitnessService().getAccessToken(str);
+            if (!(inAccessToken instanceof GatekeeperOAuth2AccessToken))
+                return null;
+            userAccessToken = (GatekeeperOAuth2AccessToken) inAccessToken;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        System.out.println("USER ID IN GATE AT: " + userAccessToken.getUserId());
+        return userAccessToken.toString();
     }
+
 
     public boolean validateAccessToken(String accessToken) {
         try {
@@ -60,6 +73,55 @@ public class GatekeeperLogin implements Serializable {
             return false;
         }
     }
+
+    public GatekeeperInfo getUserInfo() throws RuntimeException {
+        Response response = getUserInfoResponse(userAccessToken.getAccessToken());
+        JsonParser parser = new JsonParser();
+
+        JsonObject object = null;
+
+        try {
+            object = parser.parse(response.getBody()).getAsJsonObject();
+        } catch (IOException e) {
+            throw new RuntimeException(e.getCause());
+        }
+
+        if (object.has("user_type") && object.has("sub")) {
+            String userId = object.get("sub").toString();
+            UserType userType = UserType.valueOf(object.get("user_type").toString().toLowerCase());
+            return new GatekeeperInfo(userId, userType);
+        }
+
+        // See why we failed
+        if (!object.has("user_type")) {
+            throw new RuntimeException("No user_type found");
+        }
+
+        throw new RuntimeException("No user ID found");
+    }
+
+    private Response getUserInfoResponse(String accessToken) throws RuntimeException {
+        Response response;
+        try {
+            response = getUserData(accessToken);
+        } catch (InterruptedException | ExecutionException | IOException e) {
+            throw new RuntimeException(e.getCause());
+        }
+
+        if (!response.isSuccessful()) {
+            throw new RuntimeException("Response code was: " + response.getCode());
+        }
+
+        return response;
+    }
+
+    private Response getUserData(String accessToken) throws InterruptedException, ExecutionException, IOException {
+        OAuthRequest oAuthRequest = new OAuthRequest(Verb.GET, EnvironmentVariables.getGatekeeperIntrospectUrl());
+        OAuth20Service service = oAuthBean.getAberfitnessService();
+        service.signRequest(accessToken, oAuthRequest);
+        return service.execute(oAuthRequest);
+    }
+
 
     public String getUser_id() {
         if (userAccessToken != null)

--- a/src/main/java/oauth/gatekeeper/GatekeeperInfo.java
+++ b/src/main/java/oauth/gatekeeper/GatekeeperInfo.java
@@ -1,0 +1,19 @@
+package oauth.gatekeeper;
+
+public class GatekeeperInfo {
+    private String userId;
+    private UserType userType;
+
+    public GatekeeperInfo(String userId, UserType userType){
+        this.userId = userId;
+        this.userType = userType;
+    }
+
+    public UserType getUserType() {
+        return userType;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/oauth/gatekeeper/GatekeeperJsonTokenExtractor.java
+++ b/src/main/java/oauth/gatekeeper/GatekeeperJsonTokenExtractor.java
@@ -1,0 +1,67 @@
+package oauth.gatekeeper;
+
+import com.github.scribejava.core.extractors.OAuth2AccessTokenJsonExtractor;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.BadJOSEException;
+import com.nimbusds.jose.proc.JWSKeySelector;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import configuration.EnvironmentVariables;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Date;
+import java.util.regex.Pattern;
+
+public class GatekeeperJsonTokenExtractor extends OAuth2AccessTokenJsonExtractor {
+
+    private static final Pattern ACCESS_TOKEN_REGEX_PATTERN = Pattern.compile("\"access_token\"\\s*:\\s*\"(\\S*?)\"");
+
+    protected GatekeeperJsonTokenExtractor() {
+    }
+
+    public static GatekeeperJsonTokenExtractor instance() {
+        return InstanceHolder.INSTANCE;
+    }
+
+    public JWTClaimsSet getJWTClaimSet(String accessToken) throws MalformedURLException, ParseException, JOSEException, BadJOSEException {
+        ConfigurableJWTProcessor jwtProcessor = new DefaultJWTProcessor();
+        JWKSource keySrc = new RemoteJWKSet( new URL(EnvironmentVariables.getGatekeeperJWKUrl()));
+        JWSAlgorithm jwsAlgorithm = JWSAlgorithm.RS256;
+        JWSKeySelector keySelector = new JWSVerificationKeySelector(jwsAlgorithm, keySrc);
+        jwtProcessor.setJWSKeySelector(keySelector);
+        SecurityContext ctx = null;
+        return jwtProcessor.process(accessToken, ctx);
+    }
+
+    @Override
+    protected GatekeeperOAuth2AccessToken createToken(String accessToken, String tokenType, Integer expiresIn,
+                                                  String refreshToken, String scope, String response) {
+        String open_id_json = extractParameter(response, ACCESS_TOKEN_REGEX_PATTERN, false);
+        JWTClaimsSet claimsSet;
+        try {
+            claimsSet = getJWTClaimSet(open_id_json);
+            String subject = claimsSet.getSubject();
+            Date startTime = claimsSet.getNotBeforeTime(), expiryTime = claimsSet.getExpirationTime();
+
+
+            return new GatekeeperOAuth2AccessToken(accessToken, tokenType, expiresIn, refreshToken, scope,
+                    subject, response, startTime, expiryTime);
+        } catch (Exception e) {
+            System.err.println("[GatekeeperJsonTokenExtractor.createToken]: " + e.toString());
+            return null;
+        }
+    }
+
+    private static class InstanceHolder {
+
+        private static final GatekeeperJsonTokenExtractor INSTANCE = new GatekeeperJsonTokenExtractor();
+    }
+}

--- a/src/main/java/oauth/gatekeeper/GatekeeperJsonTokenExtractor.java
+++ b/src/main/java/oauth/gatekeeper/GatekeeperJsonTokenExtractor.java
@@ -51,7 +51,6 @@ public class GatekeeperJsonTokenExtractor extends OAuth2AccessTokenJsonExtractor
             String subject = claimsSet.getSubject();
             Date startTime = claimsSet.getNotBeforeTime(), expiryTime = claimsSet.getExpirationTime();
 
-
             return new GatekeeperOAuth2AccessToken(accessToken, tokenType, expiresIn, refreshToken, scope,
                     subject, response, startTime, expiryTime);
         } catch (Exception e) {

--- a/src/main/java/oauth/gatekeeper/GatekeeperOAuth2AccessToken.java
+++ b/src/main/java/oauth/gatekeeper/GatekeeperOAuth2AccessToken.java
@@ -1,0 +1,36 @@
+package oauth.gatekeeper;
+
+import com.github.scribejava.core.model.OAuth2AccessToken;
+
+import java.util.Date;
+
+public class GatekeeperOAuth2AccessToken extends OAuth2AccessToken {
+
+    private final String userId;
+    private final Date start;
+    private final Date expiry;
+
+    public GatekeeperOAuth2AccessToken(String accessToken, String openIdToken, String rawResponse) {
+        this(accessToken, null, null, null, null, openIdToken, rawResponse, null, null);
+    }
+
+    public GatekeeperOAuth2AccessToken(String accessToken, String tokenType, Integer expiresIn, String refreshToken,
+                                       String scope, String userId, String rawResponse, Date start, Date expiry) {
+        super(accessToken, tokenType, expiresIn, refreshToken, scope, rawResponse);
+        this.userId = userId;
+        this.start = start;
+        this.expiry = expiry;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public Date getStart() {
+        return start;
+    }
+
+    public Date getExpiry() {
+        return expiry;
+    }
+}

--- a/src/main/java/oauth/gatekeeper/GatekeeperOAuth2AccessToken.java
+++ b/src/main/java/oauth/gatekeeper/GatekeeperOAuth2AccessToken.java
@@ -10,10 +10,6 @@ public class GatekeeperOAuth2AccessToken extends OAuth2AccessToken {
     private final Date start;
     private final Date expiry;
 
-    public GatekeeperOAuth2AccessToken(String accessToken, String openIdToken, String rawResponse) {
-        this(accessToken, null, null, null, null, openIdToken, rawResponse, null, null);
-    }
-
     public GatekeeperOAuth2AccessToken(String accessToken, String tokenType, Integer expiresIn, String refreshToken,
                                        String scope, String userId, String rawResponse, Date start, Date expiry) {
         super(accessToken, tokenType, expiresIn, refreshToken, scope, rawResponse);

--- a/src/main/java/oauth/gatekeeper/UserType.java
+++ b/src/main/java/oauth/gatekeeper/UserType.java
@@ -1,0 +1,7 @@
+package oauth.gatekeeper;
+
+public enum UserType {
+    administrator,
+    coordinator,
+
+}

--- a/src/main/java/persistence/DatabaseConnection.java
+++ b/src/main/java/persistence/DatabaseConnection.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.Logger;
 import javax.ejb.Stateless;
 import javax.persistence.*;
 import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
 
 @Stateless
@@ -39,11 +40,11 @@ public class DatabaseConnection {
     }
 
 
-    public List<AuditData> findLogEntry(String userId, String fromTime, String toTime) throws NoResultException {
+    public List<AuditData> findLogEntry(String userId, Instant fromTime, Instant toTime) throws NoResultException {
         TypedQuery<AuditData> query = em.createNamedQuery("findLogEntry", AuditData.class);
         query.setParameter("userId", userId);
-        query.setParameter("minTime", fromTime);
-        query.setParameter("maxTime", toTime);
+        query.setParameter("minTime", fromTime.toString());
+        query.setParameter("maxTime", toTime.toString());
 
         return query.getResultList();
     }

--- a/src/main/java/rest/AuditApi.java
+++ b/src/main/java/rest/AuditApi.java
@@ -69,7 +69,10 @@ public class AuditApi {
             toTime = Instant.now().toString();
         }
 
-        List<AuditData> foundEntries = dbConnection.findLogEntry(userId, fromTime, toTime);
+        Instant startingTime = Instant.parse(fromTime);
+        Instant endingTime = Instant.parse(toTime);
+
+        List<AuditData> foundEntries = dbConnection.findLogEntry(userId, startingTime, endingTime);
 
         if (foundEntries.isEmpty()){
             return Response.status(404).build();

--- a/src/main/java/rest/AuditApi.java
+++ b/src/main/java/rest/AuditApi.java
@@ -25,7 +25,7 @@ public class AuditApi {
     private static final String DEFAULT_EMPTY_TIME = "-1000000000-01-01T00:00:00Z";
 
     @EJB
-    private DatabaseConnection dbConnection = new DatabaseConnection();
+    private DatabaseConnection dbConnection;
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)

--- a/src/main/resources/META-INF/beans.xml
+++ b/src/main/resources/META-INF/beans.xml
@@ -2,6 +2,6 @@
         xmlns="http://xmlns.jcp.org/xml/ns/javaee"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
-                      http://xmlns.jcp.org/xml/ns/javaee/beans_1_2.xsd"
-        bean-discovery-mode="all">
+                      http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd"
+        bean-discovery-mode="all" version="2.0">
 </beans>

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -9,7 +9,7 @@
         <class>entities.AuditData</class>
         <exclude-unlisted-classes>false</exclude-unlisted-classes>
         <properties>
-            <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
+            <property name="javax.persistence.schema-generation.database.action" value="create"/>
             <property name="javax.persistence.schema-generation.create-source"
                       value="metadata"/>
         </properties>

--- a/src/main/webapp/Facelets/hello.xhtml
+++ b/src/main/webapp/Facelets/hello.xhtml
@@ -5,7 +5,18 @@
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
       xmlns:f="http://xmlns.jcp.org/jsf/core">
-   <f:view>
-      <h:outputLabel value="Hello, world - GLaDOS"/>
-   </f:view>
+
+    <h:head>
+        <title>Hello</title>
+    </h:head>
+
+    <h:body>
+        <p>
+            JSF says:
+        </p>
+        <p>
+            <b>#{helloBacking.hello}</b>
+        </p>
+    </h:body>
+
 </html>

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app version="4.0" xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+   http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd">
+<servlet>
+        <servlet-name>Faces Servlet</servlet-name>
+        <servlet-class>javax.faces.webapp.FacesServlet</servlet-class>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>Faces Servlet</servlet-name>
+        <url-pattern>*.xhtml</url-pattern>
+    </servlet-mapping>
+
+    <session-config>
+        <session-timeout>
+            30
+        </session-timeout>
+    </session-config>
+
+    <welcome-file-list>
+        <welcome-file>Facelets/hello.xhtml</welcome-file>
+    </welcome-file-list>
+</web-app>

--- a/src/main/webapp/hello.xhtml
+++ b/src/main/webapp/hello.xhtml
@@ -3,8 +3,7 @@
         "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
-      xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:f="http://xmlns.jcp.org/jsf/core">
+>
 
     <h:head>
         <title>Hello</title>
@@ -15,7 +14,7 @@
             JSF says:
         </p>
         <p>
-            <b>#{helloBacking.hello}</b>
+            Hello world.
         </p>
     </h:body>
 

--- a/src/main/webapp/resources/styles/table.css
+++ b/src/main/webapp/resources/styles/table.css
@@ -1,0 +1,19 @@
+.userIdColumn{
+    width: 100px;
+}
+
+.logIdColumn{
+    width: 150px;
+}
+
+.timestampColumn{
+    width: 150px;
+}
+
+.serviceNameColumn{
+    width: 100px;
+}
+
+.contentColumn{
+    width: 300px;
+}

--- a/src/main/webapp/userDataLookup.xhtml
+++ b/src/main/webapp/userDataLookup.xhtml
@@ -15,13 +15,19 @@
     <div>
     <h:form id="dateTimeForm">
         <h:panelGrid columns="2">
-        <p:outputLabel for="startDateTime" value="From (date and time): " />
-        <p:calendar id="startDateTime" value="#{userDataLookupBacking.startingTime}" pattern="MM/dd/yyyy HH:mm:ss" />
+            <p:outputLabel for="userId" value="User ID: "/>
+            <p:inputText id="userId" value="#{userDataLookupBacking.userId}"
+                         disabled="#{!userDataLookupBacking.currentUserIsAdmin}" />
+        </h:panelGrid>
+
+        <h:panelGrid columns="2">
+            <p:outputLabel for="startDateTime" value="From: " />
+            <p:calendar id="startDateTime" value="#{userDataLookupBacking.startingTime}" pattern="MM/dd/yyyy HH:mm:ss" />
         </h:panelGrid>
 
         <h:panelGrid columns="3">
-        <p:outputLabel for="endDateTime" value="To (date and time): " />
-        <p:calendar id="endDateTime" value="#{userDataLookupBacking.endingTime}"  pattern="MM/dd/yyyy HH:mm:ss"/>
+            <p:outputLabel for="endDateTime" value="To: " />
+            <p:calendar id="endDateTime" value="#{userDataLookupBacking.endingTime}"  pattern="MM/dd/yyyy HH:mm:ss"/>
             <h:commandButton value="Submit" action="#{userDataLookupBacking.lookupResults}" />
         </h:panelGrid>
 

--- a/src/main/webapp/userDataLookup.xhtml
+++ b/src/main/webapp/userDataLookup.xhtml
@@ -4,8 +4,11 @@
       xmlns:f="http://java.sun.com/jsf/core"
       xmlns:p="http://primefaces.org/ui">
 
-<h:head>
+<f:metadata>
+    <f:viewParam name="checkLogin" value="#{userDataLookupBacking.onLoad()}#"/>
+</f:metadata>
 
+<h:head>
     <title>Audit Data Retrival</title>
 </h:head>
 
@@ -16,7 +19,7 @@
     <h:form id="dateTimeForm">
         <h:panelGrid columns="2">
             <p:outputLabel for="userId" value="User ID: "/>
-            <p:inputText id="userId" value="#{userDataLookupBacking.userId}"
+            <p:inputText id="userId" value="#{userDataLookupBacking.userToLookup}"
                          disabled="#{!userDataLookupBacking.currentUserIsAdmin}" />
         </h:panelGrid>
 

--- a/src/main/webapp/userDataLookup.xhtml
+++ b/src/main/webapp/userDataLookup.xhtml
@@ -1,0 +1,68 @@
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:value="http://java.sun.com/jsf/facelets" xml:lang="en" lang="en"
+      xmlns:composite="http://java.sun.com/jsf/composite"
+      xmlns:h="http://java.sun.com/jsf/html"
+      xmlns:f="http://java.sun.com/jsf/core"
+      xmlns:p="http://primefaces.org/ui">
+
+<h:head>
+
+    <title>Audit Data Retrival</title>
+</h:head>
+
+<h:body>
+    <h:outputStylesheet name="styles/table.css"/>
+
+    <div>
+    <h:form id="dateTimeForm">
+        <h:panelGrid columns="2">
+        <p:outputLabel for="startDateTime" value="From (date and time): " />
+        <p:calendar id="startDateTime" value="#{userDataLookupBacking.startingTime}" pattern="MM/dd/yyyy HH:mm:ss" />
+        </h:panelGrid>
+
+        <h:panelGrid columns="3">
+        <p:outputLabel for="endDateTime" value="To (date and time): " />
+        <p:calendar id="endDateTime" value="#{userDataLookupBacking.endingTime}"  pattern="MM/dd/yyyy HH:mm:ss"/>
+            <h:commandButton value="Submit" action="#{userDataLookupBacking.lookupResults}" />
+        </h:panelGrid>
+
+
+    </h:form>
+
+    </div>
+
+    <div>
+    <p:dataTable rendered="#{userDataLookupBacking.hasRequestedResults}"
+                 value="#{userDataLookupBacking.results}" var="logEntry"
+                 columnClasses="userIdColumn,logIdColumn,timestampColumn,serviceNameColumn,contentColumn">
+    
+        <p:column>
+            <f:facet name="header">User ID</f:facet>
+            #{logEntry.userId}
+        </p:column>
+
+        <p:column>
+            <f:facet name="header">Log ID</f:facet>
+            #{logEntry.logId}
+        </p:column>
+
+        <p:column>
+            <f:facet name="header">Timestamp</f:facet>
+            #{logEntry.timestamp.toString()}
+        </p:column>
+
+        <p:column>
+            <f:facet name="header">Service</f:facet>
+            #{logEntry.serviceName.toString()}
+        </p:column>
+
+        <p:column>
+            <f:facet name="header">Content</f:facet>
+            #{logEntry.content}
+        </p:column>
+    </p:dataTable>
+    </div>
+
+</h:body>
+
+
+</html>

--- a/src/test/java/UnitTest/AuditApiTest.java
+++ b/src/test/java/UnitTest/AuditApiTest.java
@@ -140,14 +140,14 @@ public class AuditApiTest {
         List<AuditData> logDataList = new ArrayList<>();
         logDataList.add(logData);
 
-        ArgumentCaptor<String> fromTime = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<String> toTime = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Instant> fromTime = ArgumentCaptor.forClass(Instant.class);
+        ArgumentCaptor<Instant> toTime = ArgumentCaptor.forClass(Instant.class);
 
         when(dbMock.findLogEntry(any(), fromTime.capture(), toTime.capture())).thenReturn(logDataList);
 
         apiInstance.findLogEntry(userId, EMPTY_TIME, EMPTY_TIME);
-        Assert.assertEquals(fromTime.getValue(), EMPTY_TIME);
-        Assert.assertNotEquals(toTime.getValue(), EMPTY_TIME);
+        Assert.assertEquals(fromTime.getValue().toString(), EMPTY_TIME);
+        Assert.assertNotEquals(toTime.getValue().toString(), EMPTY_TIME);
 
     }
 


### PR DESCRIPTION
**#28  Must be reviewed first** 
Adds a field to the existing PR to lookup a specific user
For non-admins this is greyed out and set to only their user ID
An admin can select the user ID here

Also implements querying the Gatekeeper API for user data