### PR TITLE
Update persistence layer to store string instead of enum

### DIFF
--- a/glados.iml
+++ b/glados.iml
@@ -24,13 +24,13 @@
     <facet type="jpa" name="JPA">
       <configuration>
         <setting name="validation-enabled" value="true" />
+        <setting name="provider-name" value="" />
         <datasource-mapping>
           <factory-entry name="Entities" />
           <factory-entry name="GLaDOSPU" />
           <factory-entry name="GladosPU" />
           <factory-entry name="gladosPU" />
         </datasource-mapping>
-        <naming-strategy-map />
         <deploymentDescriptor name="persistence.xml" url="file://$MODULE_DIR$/src/main/resources/META-INF/persistence.xml" />
       </configuration>
     </facet>

--- a/src/main/java/entities/AuditData.java
+++ b/src/main/java/entities/AuditData.java
@@ -1,7 +1,6 @@
 package entities;
 
 import persistence.helpers.InstantConverter;
-import rest.helpers.ServiceNames;
 
 import javax.persistence.*;
 import java.io.Serializable;
@@ -31,8 +30,7 @@ public class AuditData implements Serializable {
     private String logId;
 
     @Column(name = "serviceName", nullable = false, length = 20)
-    @Enumerated(EnumType.STRING)
-    private ServiceNames serviceName;
+    private String serviceName;
 
     @Column(name = "timestamp", nullable = false)
     @Convert(converter = InstantConverter.class)
@@ -55,7 +53,7 @@ public class AuditData implements Serializable {
      * @param serviceName The service associated with this log entry
      */
     public AuditData(final Instant timestamp,
-                     final String content, final String userId, final ServiceNames serviceName) {
+                     final String content, final String userId, final String serviceName) {
         this.logId = UUID.randomUUID().toString();
         this.timestamp = timestamp;
         this.content = content;
@@ -117,13 +115,13 @@ public class AuditData implements Serializable {
     /**
      * Returns the service which created this log
      *
-     * @return ServiceName enum with the micro-service name
+     * @return ServiceName string with the micro-service name
      */
-    public ServiceNames getServiceName() {
+    public String getServiceName() {
         return serviceName;
     }
 
-    public void setServiceName(ServiceNames serviceName) {
+    public void setServiceName(String serviceName) {
         this.serviceName = serviceName;
     }
 

--- a/src/main/java/entities/AuditDataJson.java
+++ b/src/main/java/entities/AuditDataJson.java
@@ -1,6 +1,5 @@
 package entities;
 
-import rest.helpers.ServiceNames;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
@@ -25,7 +24,7 @@ public class AuditDataJson extends AuditData {
      * @param serviceName The micro-service associated with this log entry
      */
     public AuditDataJson(final Instant timestamp,
-                         final String content, final String userId, final ServiceNames serviceName){
+                         final String content, final String userId, final String serviceName){
         super(timestamp, content, userId, serviceName);
     }
 
@@ -49,7 +48,7 @@ public class AuditDataJson extends AuditData {
                 .add("timestamp", getTimestamp().toString())
                 .add("userId", getUserId())
                 .add("content", getContent())
-                .add("serviceName", getServiceName().toString());
+                .add("serviceName", getServiceName());
         return newJson.build();
     }
 

--- a/src/test/java/UnitTest/AuditApiTest.java
+++ b/src/test/java/UnitTest/AuditApiTest.java
@@ -65,7 +65,7 @@ public class AuditApiTest {
         when(authMock.getUserInfo()).thenReturn(mockedUserInfo);
 
         return new AuditData(Instant.now(), "TestContent",
-                userId, ServiceNames.GLADOS);
+                userId, ServiceNames.GLADOS.toString());
     }
 
 //    @Test

--- a/src/test/java/UnitTest/AuditDataJsonTest.java
+++ b/src/test/java/UnitTest/AuditDataJsonTest.java
@@ -32,7 +32,7 @@ public class AuditDataJsonTest {
     @Test
     public void ConvertsFromOtherSerialisingTypeCorrectly() {
         AuditData noSerial = new AuditData(Instant.now(),
-                "test", "abc123", ServiceNames.GLADOS);
+                "test", "abc123", ServiceNames.GLADOS.toString());
 
         AuditDataJson convertedInstance = new AuditDataJson(noSerial);
         Assert.assertNotNull(convertedInstance);
@@ -46,7 +46,7 @@ public class AuditDataJsonTest {
         Instant now = Instant.now();
         String sampleMsg = "Hello world";
         String userId = "test123";
-        ServiceNames serviceName = ServiceNames.GLADOS;
+        String serviceName = ServiceNames.GLADOS.toString();
 
         final AuditDataJson testInstance = new AuditDataJson(now, sampleMsg, userId, serviceName);
         JsonObject returnedJson = testInstance.toJson();
@@ -64,7 +64,7 @@ public class AuditDataJsonTest {
         String sampleMsg = "Hello world";
 
         String userId = "test123";
-        ServiceNames serviceName = ServiceNames.GLADOS;
+        String serviceName = ServiceNames.GLADOS.toString();
 
         AuditData referenceInstance = new AuditData(now, sampleMsg, userId, serviceName);
 
@@ -78,7 +78,7 @@ public class AuditDataJsonTest {
     public void SerialisesFromListCorrectly() {
         Instant now = Instant.now();
         String sampleMsg = "Hello world";
-        ServiceNames serviceName = ServiceNames.GLADOS;
+        String serviceName = ServiceNames.GLADOS.toString();
 
         final AuditDataJson testObjOne = new AuditDataJson(now, sampleMsg, "101", serviceName);
         final AuditDataJson testObjTwo = new AuditDataJson(now, sampleMsg, "102", serviceName);
@@ -106,7 +106,7 @@ public class AuditDataJsonTest {
         Instant now = Instant.now();
         String sampleMsg = "Hello world";
         String userId = "test123";
-        ServiceNames serviceName = ServiceNames.GLADOS;
+        String serviceName = ServiceNames.GLADOS.toString();
 
         final AuditDataJson testInstance = new AuditDataJson(now, sampleMsg, userId, serviceName);
 

--- a/src/test/java/UnitTest/AuditDataTest.java
+++ b/src/test/java/UnitTest/AuditDataTest.java
@@ -14,7 +14,7 @@ public class AuditDataTest {
         Instant now = Instant.now();
         String sampleMsg = "Hello world";
         String userId = "test123";
-        ServiceNames testName = ServiceNames.GLADOS;
+        String testName = ServiceNames.GLADOS.toString();
 
         final AuditData testInstance = new AuditData(now, sampleMsg, userId, testName);
 
@@ -29,9 +29,9 @@ public class AuditDataTest {
         Instant now = Instant.now();
 
         // Regardless of other fields the log id should always be unique
-        final AuditData testInstanceOne = new AuditData(now, "test", "id1", ServiceNames.GLADOS);
+        final AuditData testInstanceOne = new AuditData(now, "test", "id1", ServiceNames.GLADOS.toString());
         final AuditData testInstanceTwo = new AuditData(now,
-                "test", "id1", ServiceNames.GLADOS);
+                "test", "id1", ServiceNames.GLADOS.toString());
 
         Assert.assertNotEquals(testInstanceOne.getLogId(), testInstanceTwo.getLogId());
     }
@@ -39,7 +39,7 @@ public class AuditDataTest {
     @Test
     public void LogDataCopyConstructor() {
         final AuditData testInstanceOne = new AuditData(Instant.now(),
-                "test", "id1", ServiceNames.GLADOS);
+                "test", "id1", ServiceNames.GLADOS.toString());
 
         final AuditData testInstanceTwo = new AuditData(testInstanceOne);
 


### PR DESCRIPTION
This allows any services with a dash in the name to store values, when before they could not